### PR TITLE
django filefield paths need to be relative. PMT #97916

### DIFF
--- a/footprints/main/models.py
+++ b/footprints/main/models.py
@@ -123,7 +123,7 @@ class DigitalFormat(models.Model):
 class DigitalObject(models.Model):
     name = models.CharField(max_length=500)
     digital_format = models.ForeignKey(DigitalFormat)
-    file = models.FileField(upload_to="/%Y/%m/%d/")
+    file = models.FileField(upload_to="digitalobjects/%Y/%m/%d/")
 
     source_url = models.URLField(null=True, blank=True)
     notes = models.TextField(null=True, blank=True)


### PR DESCRIPTION
@sdreher, here you go.

Django doesn't like it if the path starts with '/'.

I also took the liberty of putting uploads within 'digitalobjects' instead of straight at the
root of the uploads directory. IME, if you later have other model types that want to upload
files, it will be good to keep them seperate from the beginning.

Anyway, I was able to reproduce the 400 error locally, and this fixes it. Should work on
production too.

I'm also going to go in on itchy and make the uploads directory the proper symlink
to the NFS server, but that should be unrelated.

If you're doing uploads on this app, it would also probably be good to go take a look
at the nginx config and make sure it isn't set to block anything too small (again,
unrelated to the current issue, but worth keeping in mind).

Long term, I recommend thinking about S3 for all our user uploads.
