### PR TITLE
Refactor clientside render

### DIFF
--- a/footprints/main/models.py
+++ b/footprints/main/models.py
@@ -269,6 +269,12 @@ class Place(models.Model):
 
         return ', '.join(parts)
 
+    def latitude(self):
+        return self.position.latitude
+
+    def longitude(self):
+        return self.position.longitude
+
 
 class Collection(models.Model):
     name = models.CharField(max_length=512, unique=True)

--- a/footprints/main/serializers.py
+++ b/footprints/main/serializers.py
@@ -88,6 +88,9 @@ class ExtendedDateFormatSerializer(HyperlinkedModelSerializerEx):
         model = ExtendedDateFormat
         fields = ('id', 'edtf_format',)
 
+    def get_queryset(self):
+        return ExtendedDateFormat.objects.all()
+
 
 class RoleSerializer(HyperlinkedModelSerializer):
     class Meta:
@@ -96,9 +99,12 @@ class RoleSerializer(HyperlinkedModelSerializer):
 
 
 class PersonSerializer(HyperlinkedModelSerializer):
+    birth_date = ExtendedDateFormatSerializer()
+    death_date = ExtendedDateFormatSerializer()
+
     class Meta:
         model = Person
-        fields = ('id', 'name')
+        fields = ('id', 'name', 'birth_date', 'death_date')
 
 
 class PlaceSerializer(HyperlinkedModelSerializerEx):
@@ -140,7 +146,7 @@ class ActorSerializer(HyperlinkedModelSerializer):
         return ManyRelatedFieldEx(**list_kwargs)
 
 
-class WrittenWorkSerializer(HyperlinkedModelSerializer):
+class WrittenWorkSerializer(HyperlinkedModelSerializerEx):
     actor = ActorSerializer(many=True)
 
     class Meta:
@@ -148,16 +154,17 @@ class WrittenWorkSerializer(HyperlinkedModelSerializer):
         fields = ('id', 'title', 'actor', 'notes')
 
 
-class ImprintSerializer(HyperlinkedModelSerializer):
+class ImprintSerializer(HyperlinkedModelSerializerEx):
     work = WrittenWorkSerializer()
     language = LanguageSerializer(many=True)
     actor = ActorSerializer(many=True)
     place = PlaceSerializer()
+    date_of_publication = ExtendedDateFormatSerializer()
 
     class Meta:
         model = Imprint
         # @todo digital_object, standardized_identifier
-        fields = ('work', 'title', 'language', 'place',
+        fields = ('id', 'work', 'title', 'language', 'place',
                   'date_of_publication', 'actor', 'notes')
 
     def update(self, instance, validated_data):
@@ -165,7 +172,7 @@ class ImprintSerializer(HyperlinkedModelSerializer):
             instance.language = validated_data['language']
             instance.save()
         else:
-            instance = super(FootprintSerializer, self).update(
+            instance = super(ImprintSerializer, self).update(
                 instance, validated_data)
 
         return instance

--- a/footprints/main/serializers.py
+++ b/footprints/main/serializers.py
@@ -2,13 +2,11 @@ from django.contrib.auth.models import User
 from django.core.exceptions import ObjectDoesNotExist
 from rest_framework.fields import CharField, ReadOnlyField, empty
 from rest_framework.relations import (ManyRelatedField, MANY_RELATION_KWARGS)
-from rest_framework.serializers import Serializer, HyperlinkedModelSerializer, \
-    raise_errors_on_nested_writes
+from rest_framework.serializers import Serializer, HyperlinkedModelSerializer
 from rest_framework.utils import html
-import six
 
 from footprints.main.models import Footprint, Language, Role, Actor, \
-    ExtendedDateFormat, Person, Place, WrittenWork
+    ExtendedDateFormat, Person, Place, WrittenWork, Imprint, BookCopy
 
 
 # Fixes a django-restframework bug, patch submitted & will be available 3.0.5
@@ -21,8 +19,25 @@ class ManyRelatedFieldEx(ManyRelatedField):
             if self.field_name not in dictionary:
                 if getattr(self.root, 'partial', False):
                     return empty
+            elif len(dictionary[self.field_name]) < 1:
+                return []
+            else:
+                return dictionary.getlist(self.field_name)
 
-            return dictionary.getlist(self.field_name)
+        return dictionary.get(self.field_name, empty)
+
+
+class HyperlinkedModelSerializerEx(HyperlinkedModelSerializer):
+    def get_value(self, dictionary):
+        # We override the default field access in order to support
+        # lists in HTML forms.
+        if html.is_html_input(dictionary):
+            # Don't return [] if the update is partial
+            if self.field_name not in dictionary:
+                if getattr(self.root, 'partial', False):
+                    return empty
+            elif len(dictionary[self.field_name]) < 1:
+                return {}
 
         return dictionary.get(self.field_name, empty)
 
@@ -48,32 +63,17 @@ class LanguageSerializer(HyperlinkedModelSerializer):
         model = Language
         fields = ('id', 'name')
 
-    def get_value(self, dictionary):
-        # We override the default field access in order to support
-        # nested HTML forms.
-        if html.is_html_input(dictionary):
-            return html.parse_html_dict(dictionary, prefix=self.field_name)
-        return dictionary.get(self.field_name, empty)
+    def get_queryset(self):
+        return Language.objects.all()
 
-    def run_validation(self, data=empty):
-        """
-        We override the default `run_validation`, because the validation
-        performed by validators and the `.validate()` method should
-        be coerced into an error dictionary with a 'non_fields_error' key.
-        """
-        (is_empty_value, data) = self.validate_empty_values(data)
-        if is_empty_value:
-            return data
-
-        value = self.to_internal_value(data)
+    def to_internal_value(self, data):
         try:
-            self.run_validators(value)
-            value = self.validate(value)
-            assert value is not None, '.validate() should return the validated data'
-        except (ValidationError, DjangoValidationError) as exc:
-            raise ValidationError(detail=get_validation_error_detail(exc))
+            return self.get_queryset().get(pk=data)
+        except ObjectDoesNotExist:
+            self.fail('does_not_exist', pk_value=data)
+        except (TypeError, ValueError):
+            self.fail('incorrect_type', data_type=type(data).__name__)
 
-        return value
     @classmethod
     def many_init(cls, *args, **kwargs):
         list_kwargs = {'child_relation': cls(*args, **kwargs)}
@@ -83,7 +83,7 @@ class LanguageSerializer(HyperlinkedModelSerializer):
         return ManyRelatedFieldEx(**list_kwargs)
 
 
-class ExtendedDateFormatSerializer(HyperlinkedModelSerializer):
+class ExtendedDateFormatSerializer(HyperlinkedModelSerializerEx):
     class Meta:
         model = ExtendedDateFormat
         fields = ('id', 'edtf_format',)
@@ -101,7 +101,7 @@ class PersonSerializer(HyperlinkedModelSerializer):
         fields = ('id', 'name')
 
 
-class PlaceSerializer(HyperlinkedModelSerializer):
+class PlaceSerializer(HyperlinkedModelSerializerEx):
     display_title = ReadOnlyField(source='__unicode__')
     latitude = ReadOnlyField()
     longitude = ReadOnlyField()
@@ -120,6 +120,17 @@ class ActorSerializer(HyperlinkedModelSerializer):
         model = Actor
         fields = ('id', 'alias', 'person', 'role')
 
+    def get_queryset(self):
+        return Actor.objects.all()
+
+    def to_internal_value(self, data):
+        try:
+            return self.get_queryset().get(pk=data)
+        except ObjectDoesNotExist:
+            self.fail('does_not_exist', pk_value=data)
+        except (TypeError, ValueError):
+            self.fail('incorrect_type', data_type=type(data).__name__)
+
     @classmethod
     def many_init(cls, *args, **kwargs):
         list_kwargs = {'child_relation': cls(*args, **kwargs)}
@@ -137,6 +148,37 @@ class WrittenWorkSerializer(HyperlinkedModelSerializer):
         fields = ('id', 'title', 'actor', 'notes')
 
 
+class ImprintSerializer(HyperlinkedModelSerializer):
+    work = WrittenWorkSerializer()
+    language = LanguageSerializer(many=True)
+    actor = ActorSerializer(many=True)
+    place = PlaceSerializer()
+
+    class Meta:
+        model = Imprint
+        # @todo digital_object, standardized_identifier
+        fields = ('work', 'title', 'language', 'place',
+                  'date_of_publication', 'actor', 'notes')
+
+    def update(self, instance, validated_data):
+        if 'language' in validated_data:
+            instance.language = validated_data['language']
+            instance.save()
+        else:
+            instance = super(FootprintSerializer, self).update(
+                instance, validated_data)
+
+        return instance
+
+
+class BookCopySerializer(HyperlinkedModelSerializer):
+    imprint = ImprintSerializer()
+
+    class Meta:
+        model = BookCopy
+        fields = ('id', 'imprint', 'notes')
+
+
 class FootprintSerializer(HyperlinkedModelSerializer):
     associated_date = ExtendedDateFormatSerializer()
     language = LanguageSerializer(many=True)
@@ -147,13 +189,16 @@ class FootprintSerializer(HyperlinkedModelSerializer):
         model = Footprint
         fields = ('id', 'medium', 'medium_description',
                   'provenance', 'title', 'language', 'actor', 'call_number',
-                  'notes', 'associated_date', 'place', 'narrative')
+                  'notes', 'associated_date', 'place', 'narrative',
+                  'percent_complete')
 
     def update(self, instance, validated_data):
-        raise_errors_on_nested_writes('update', self, validated_data)
-
-        for attr, value in validated_data.items():
-            setattr(instance, attr, value)
-        instance.save()
+        if 'language' in validated_data:
+            # all related languages are posted
+            instance.language = validated_data['language']
+            instance.save()
+        else:
+            instance = super(FootprintSerializer, self).update(
+                instance, validated_data)
 
         return instance

--- a/footprints/main/views.py
+++ b/footprints/main/views.py
@@ -1,7 +1,6 @@
 from django.conf import settings
 from django.contrib.auth import login
 from django.contrib.auth.forms import AuthenticationForm
-from django.contrib.auth.models import User
 from django.contrib.auth.views import logout as auth_logout_view
 from django.core.urlresolvers import reverse
 from django.http.response import HttpResponseRedirect, HttpResponseForbidden
@@ -10,7 +9,6 @@ from django.views.generic.base import TemplateView, View
 from django.views.generic.detail import DetailView
 from djangowind.views import logout as wind_logout_view
 from haystack.query import SearchQuerySet
-from rest_framework import viewsets
 from rest_framework.permissions import AllowAny
 from rest_framework.renderers import JSONPRenderer
 from rest_framework.response import Response
@@ -19,11 +17,8 @@ from rest_framework.views import APIView
 from footprints.main.models import (
     Footprint, Actor, Person, Role, WrittenWork, Language, ExtendedDateFormat,
     Place, Imprint, BookCopy)
-from footprints.main.permissions import IsStaffOrReadOnly
 from footprints.main.serializers import (
-    TitleSerializer, NameSerializer, FootprintSerializer, LanguageSerializer,
-    RoleSerializer, ExtendedDateFormatSerializer, ActorSerializer,
-    PersonSerializer, PlaceSerializer, WrittenWorkSerializer, UserSerializer)
+    TitleSerializer, NameSerializer, ActorSerializer)
 from footprints.mixins import (
     JSONResponseMixin, LoggedInMixin, EditableMixin)
 
@@ -291,57 +286,3 @@ class NameListView(APIView):
             return Response(serializer.data)
         else:
             return Response({})
-
-
-class FootprintViewSet(viewsets.ModelViewSet):
-    queryset = Footprint.objects.all()
-    serializer_class = FootprintSerializer
-    permission_classes = (IsStaffOrReadOnly,)
-
-
-class LanguageViewSet(viewsets.ModelViewSet):
-    queryset = Language.objects.all()
-    serializer_class = LanguageSerializer
-    permission_classes = (IsStaffOrReadOnly,)
-
-
-class RoleViewSet(viewsets.ModelViewSet):
-    queryset = Role.objects.all()
-    serializer_class = RoleSerializer
-    permission_classes = (IsStaffOrReadOnly,)
-
-
-class ExtendedDateFormatViewSet(viewsets.ModelViewSet):
-    queryset = ExtendedDateFormat.objects.all()
-    serializer_class = ExtendedDateFormatSerializer
-    permission_classes = (IsStaffOrReadOnly,)
-
-
-class PersonViewSet(viewsets.ModelViewSet):
-    queryset = Person.objects.all()
-    serializer_class = PersonSerializer
-    permission_classes = (IsStaffOrReadOnly,)
-
-
-class PlaceViewSet(viewsets.ModelViewSet):
-    queryset = Place.objects.all()
-    serializer_class = PlaceSerializer
-    permission_classes = (IsStaffOrReadOnly,)
-
-
-class ActorViewSet(viewsets.ModelViewSet):
-    queryset = Actor.objects.all()
-    serializer_class = ActorSerializer
-    permission_classes = (IsStaffOrReadOnly,)
-
-
-class WrittenWorkViewSet(viewsets.ModelViewSet):
-    queryset = WrittenWork.objects.all()
-    serializer_class = WrittenWorkSerializer
-    permission_classes = (IsStaffOrReadOnly,)
-
-
-class UserViewSet(viewsets.ModelViewSet):
-    queryset = User.objects.all()
-    serializer_class = UserSerializer
-    permission_classes = (IsStaffOrReadOnly,)

--- a/footprints/main/views.py
+++ b/footprints/main/views.py
@@ -1,3 +1,4 @@
+from django.apps import apps
 from django.conf import settings
 from django.contrib.auth import login
 from django.contrib.auth.forms import AuthenticationForm
@@ -17,8 +18,7 @@ from rest_framework.views import APIView
 from footprints.main.models import (
     Footprint, Actor, Person, Role, WrittenWork, Language, ExtendedDateFormat,
     Place, Imprint, BookCopy)
-from footprints.main.serializers import (
-    TitleSerializer, NameSerializer, ActorSerializer)
+from footprints.main.serializers import TitleSerializer, NameSerializer
 from footprints.mixins import (
     JSONResponseMixin, LoggedInMixin, EditableMixin)
 
@@ -130,24 +130,43 @@ class CreateFootprintView(LoggedInMixin, TemplateView):
         return HttpResponseRedirect(url)
 
 
-class FootprintRemoveActorView(LoggedInMixin, EditableMixin,
-                               JSONResponseMixin, View):
+class RemoveRelatedView(LoggedInMixin, EditableMixin,
+                        JSONResponseMixin, View):
 
     def post(self, *args, **kwargs):
-        footprint_id = kwargs.get('footprint_id', None)
-        footprint = get_object_or_404(Footprint, pk=footprint_id)
+        try:
+            model_name = self.request.POST.get('parent_model', None)
+            the_model = apps.get_model(app_label='main', model_name=model_name)
 
-        if not self.has_edit_permission(self.request.user, footprint):
+            the_parent = get_object_or_404(
+                the_model, pk=self.request.POST.get('parent_id', None))
+        except ValueError:
+            return self.render_to_json_response({'success': False})
+
+        if not self.has_edit_permission(self.request.user, the_parent):
             return HttpResponseForbidden()
 
-        actor_id = kwargs.get('actor_id', None)
-        actor = get_object_or_404(Actor, id=actor_id)
-        footprint.actor.remove(actor)
+        # cheating a bit here. @todo - make this totally generic
+        # will need to figure out whether related is FK or M2M
+        actor_id = self.request.POST.get('actor_id', None)
+        place_id = self.request.POST.get('place_id', None)
+        if actor_id is None and place_id is None:
+            return self.render_to_json_response({'success': False})
+
+        if actor_id:
+            actor = get_object_or_404(Actor, id=actor_id)
+            the_parent.actor.remove(actor)
+        elif place_id:
+            place = get_object_or_404(Place, id=place_id)
+            if the_parent.place == place:
+                the_parent.place = None
+                the_parent.save()
+
         return self.render_to_json_response({'success': True})
 
 
-class FootprintAddActorView(LoggedInMixin, EditableMixin,
-                            JSONResponseMixin, View):
+class AddActorView(LoggedInMixin, EditableMixin,
+                   JSONResponseMixin, View):
 
     def create_actor(self, person_id, person_name, role, alias):
         try:
@@ -161,8 +180,14 @@ class FootprintAddActorView(LoggedInMixin, EditableMixin,
         return Actor.objects.create(person=person, role=role, alias=alias)
 
     def post(self, *args, **kwargs):
-        footprint_id = kwargs.get('footprint_id', None)
-        footprint = get_object_or_404(Footprint, pk=footprint_id)
+        parent_model = self.request.POST.get('parent_model', None)
+        the_model = apps.get_model(app_label='main', model_name=parent_model)
+
+        parent_id = self.request.POST.get('parent_id', None)
+        the_parent = get_object_or_404(the_model, pk=parent_id)
+
+        if not self.has_edit_permission(self.request.user, the_parent):
+            return HttpResponseForbidden()
 
         role = get_object_or_404(Role, pk=self.request.POST.get('role', None))
 
@@ -171,36 +196,33 @@ class FootprintAddActorView(LoggedInMixin, EditableMixin,
         alias = self.request.POST.get('alias', None)
 
         actor = self.create_actor(person_id, person_name, role, alias)
-        footprint.actor.add(actor)
+        the_parent.actor.add(actor)
 
-        return self.render_to_json_response({
-            'success': True,
-            'footprint': {'id': footprint.id},
-            'actor': ActorSerializer(actor).data
-        })
+        return self.render_to_json_response({'success': True})
 
 
-class FootprintAddDateView(LoggedInMixin, EditableMixin,
-                           JSONResponseMixin, View):
+class AddDateView(LoggedInMixin, EditableMixin,
+                  JSONResponseMixin, View):
 
     def post(self, *args, **kwargs):
-        footprint_id = kwargs.get('footprint_id', None)
-        footprint = get_object_or_404(Footprint, pk=footprint_id)
+        parent_model = self.request.POST.get('parent_model', None)
+        the_model = apps.get_model(app_label='main', model_name=parent_model)
 
-        if not self.has_edit_permission(self.request.user, footprint):
+        parent_id = self.request.POST.get('parent_id', None)
+        the_parent = get_object_or_404(the_model, pk=parent_id)
+
+        attr = self.request.POST.get('attr', None)
+
+        if not self.has_edit_permission(self.request.user, the_parent):
             return HttpResponseForbidden()
 
-        date_string = self.request.POST.get('associated_date', None)
+        date_string = self.request.POST.get('date_string', None)
         if date_string is not None:
             edtf = ExtendedDateFormat.objects.create(edtf_format=date_string)
-            footprint.associated_date = edtf
-            footprint.save()
+            setattr(the_parent, attr, edtf)
+            the_parent.save()
 
-            return self.render_to_json_response({
-                'success': True,
-                'footprint_id': footprint.id,
-                'associated_date': edtf.id
-            })
+            return self.render_to_json_response({'success': True})
         else:
             return self.render_to_json_response({
                 'success': False,
@@ -208,14 +230,17 @@ class FootprintAddDateView(LoggedInMixin, EditableMixin,
             })
 
 
-class FootprintAddPlaceView(LoggedInMixin, EditableMixin,
-                            JSONResponseMixin, View):
+class AddPlaceView(LoggedInMixin, EditableMixin,
+                   JSONResponseMixin, View):
 
     def post(self, *args, **kwargs):
-        footprint_id = kwargs.get('footprint_id', None)
-        footprint = get_object_or_404(Footprint, pk=footprint_id)
+        parent_model = self.request.POST.get('parent_model', None)
+        the_model = apps.get_model(app_label='main', model_name=parent_model)
 
-        if not self.has_edit_permission(self.request.user, footprint):
+        parent_id = self.request.POST.get('parent_id', None)
+        the_parent = get_object_or_404(the_model, pk=parent_id)
+
+        if not self.has_edit_permission(self.request.user, the_parent):
             return HttpResponseForbidden()
 
         position = self.request.POST.get('position', '')
@@ -230,35 +255,8 @@ class FootprintAddPlaceView(LoggedInMixin, EditableMixin,
             country=self.request.POST.get('country', ''),
             position=position)
 
-        footprint.place = place
-        footprint.save()
-
-        return self.render_to_json_response({
-            'success': True,
-            'place': {
-                'id': place.id,
-                'description': place.__unicode__(),
-            },
-            'footprint_id': footprint.id
-        })
-
-
-class FootprintRemovePlaceView(LoggedInMixin, EditableMixin,
-                               JSONResponseMixin, View):
-
-    def post(self, *args, **kwargs):
-        footprint_id = kwargs.get('footprint_id', None)
-        footprint = get_object_or_404(Footprint, pk=footprint_id)
-
-        if not self.has_edit_permission(self.request.user, footprint):
-            return HttpResponseForbidden()
-
-        place_id = kwargs.get('place_id', None)
-        place = get_object_or_404(Place, id=place_id)
-
-        if footprint.place == place:
-            footprint.place = None
-            footprint.save()
+        the_parent.place = place
+        the_parent.save()
 
         return self.render_to_json_response({'success': True})
 

--- a/footprints/main/views.py
+++ b/footprints/main/views.py
@@ -1,6 +1,7 @@
 from django.conf import settings
 from django.contrib.auth import login
 from django.contrib.auth.forms import AuthenticationForm
+from django.contrib.auth.models import User
 from django.contrib.auth.views import logout as auth_logout_view
 from django.core.urlresolvers import reverse
 from django.http.response import HttpResponseRedirect, HttpResponseForbidden
@@ -22,7 +23,7 @@ from footprints.main.permissions import IsStaffOrReadOnly
 from footprints.main.serializers import (
     TitleSerializer, NameSerializer, FootprintSerializer, LanguageSerializer,
     RoleSerializer, ExtendedDateFormatSerializer, ActorSerializer,
-    PersonSerializer, PlaceSerializer, WrittenWorkSerializer)
+    PersonSerializer, PlaceSerializer, WrittenWorkSerializer, UserSerializer)
 from footprints.mixins import (
     JSONResponseMixin, LoggedInMixin, EditableMixin)
 
@@ -337,4 +338,10 @@ class ActorViewSet(viewsets.ModelViewSet):
 class WrittenWorkViewSet(viewsets.ModelViewSet):
     queryset = WrittenWork.objects.all()
     serializer_class = WrittenWorkSerializer
+    permission_classes = (IsStaffOrReadOnly,)
+
+
+class UserViewSet(viewsets.ModelViewSet):
+    queryset = User.objects.all()
+    serializer_class = UserSerializer
     permission_classes = (IsStaffOrReadOnly,)

--- a/footprints/main/viewsets.py
+++ b/footprints/main/viewsets.py
@@ -1,0 +1,78 @@
+from django.contrib.auth.models import User
+from rest_framework import viewsets
+
+from footprints.main.models import (
+    Footprint, Actor, Person, Role, WrittenWork, Language, ExtendedDateFormat,
+    Place, Imprint, BookCopy)
+from footprints.main.permissions import IsStaffOrReadOnly
+from footprints.main.serializers import (
+    FootprintSerializer, LanguageSerializer,
+    RoleSerializer, ExtendedDateFormatSerializer, ActorSerializer,
+    PersonSerializer, PlaceSerializer, WrittenWorkSerializer, UserSerializer,
+    ImprintSerializer, BookCopySerializer)
+
+
+class FootprintViewSet(viewsets.ModelViewSet):
+    queryset = Footprint.objects.all()
+    serializer_class = FootprintSerializer
+    permission_classes = (IsStaffOrReadOnly,)
+
+
+class LanguageViewSet(viewsets.ModelViewSet):
+    queryset = Language.objects.all()
+    serializer_class = LanguageSerializer
+    permission_classes = (IsStaffOrReadOnly,)
+
+
+class RoleViewSet(viewsets.ModelViewSet):
+    queryset = Role.objects.all()
+    serializer_class = RoleSerializer
+    permission_classes = (IsStaffOrReadOnly,)
+
+
+class ExtendedDateFormatViewSet(viewsets.ModelViewSet):
+    queryset = ExtendedDateFormat.objects.all()
+    serializer_class = ExtendedDateFormatSerializer
+    permission_classes = (IsStaffOrReadOnly,)
+
+
+class PersonViewSet(viewsets.ModelViewSet):
+    queryset = Person.objects.all()
+    serializer_class = PersonSerializer
+    permission_classes = (IsStaffOrReadOnly,)
+
+
+class PlaceViewSet(viewsets.ModelViewSet):
+    queryset = Place.objects.all()
+    serializer_class = PlaceSerializer
+    permission_classes = (IsStaffOrReadOnly,)
+
+
+class ActorViewSet(viewsets.ModelViewSet):
+    queryset = Actor.objects.all()
+    serializer_class = ActorSerializer
+    permission_classes = (IsStaffOrReadOnly,)
+
+
+class WrittenWorkViewSet(viewsets.ModelViewSet):
+    queryset = WrittenWork.objects.all()
+    serializer_class = WrittenWorkSerializer
+    permission_classes = (IsStaffOrReadOnly,)
+
+
+class UserViewSet(viewsets.ModelViewSet):
+    queryset = User.objects.all()
+    serializer_class = UserSerializer
+    permission_classes = (IsStaffOrReadOnly,)
+
+
+class ImprintViewSet(viewsets.ModelViewSet):
+    queryset = Imprint.objects.all()
+    serializer_class = ImprintSerializer
+    permission_classes = (IsStaffOrReadOnly,)
+
+
+class BookCopyViewSet(viewsets.ModelViewSet):
+    queryset = BookCopy.objects.all()
+    serializer_class = BookCopySerializer
+    permission_classes = (IsStaffOrReadOnly,)

--- a/footprints/templates/clientside/footprint.html
+++ b/footprints/templates/clientside/footprint.html
@@ -15,7 +15,7 @@
         <% if (associated_date) { %>
             <dt>Footprint Date</dt>
             <dd class="border-bottom">
-                <a href="#" class="<% if (editable) { %>editable-required<% } else { %>readonly<% } %>"
+                <a href="#" class="<% if (editable) { %>editable<% } else { %>readonly<% } %>"
                  data-name="edtf_format"
                  data-type="text" data-pk="<%=associated_date.id%>"
                  data-params="{csrfmiddlewaretoken:'<%=csrf_token%>'}"
@@ -31,8 +31,8 @@
                 <div class="pull-right">
                     <% if (editable) { %>
                         <a href="#" class="remove-related"
-                            data-params="{csrfmiddlewaretoken:'<%=csrf_token%>'}" 
-                            data-url="/footprint/place/<%=id%>/remove/<%=place.id%>/"
+                            data-params="{place_id:'<%=place.id%>',csrfmiddlewaretoken:'<%=csrf_token%>',parent_id:<%=id%>,parent_model:'footprint'}" 
+                            data-url="/remove/related/"
                             title="remove place">
                             <span class="glyphicon glyphicon-remove" aria-hidden="true"></span>
                         </a>
@@ -67,7 +67,7 @@
         <% } %>
         <dt title="the written work's title exactly as it appears in the of evidence.">Footprint Title Display<br /></dt>
         <dd class="border-bottom">
-            <a href="#" class="<% if (editable) { %>editable-required<% } else { %>readonly<% } %>"
+            <a href="#" class="<% if (editable) { %>editable<% } else { %>readonly<% } %>"
                 data-name="title"
                 data-type="text" data-pk="<%=id%>"
                 data-params="{csrfmiddlewaretoken:'<%=csrf_token%>'}" 
@@ -80,8 +80,8 @@
                 <div class="pull-right">
                     <% if (editable) { %>
                         <a href="#" class="remove-related"
-                            data-params="{csrfmiddlewaretoken:'<%=csrf_token%>'}" 
-                            data-url="/footprint/actor/<%=id%>/remove/<%=actor[i].id%>/"
+                            data-params="{actor_id:'<%=actor[i].id%>',csrfmiddlewaretoken:'<%=csrf_token%>',parent_id:<%=id%>,parent_model:'footprint'}" 
+                            data-url="/remove/related/"
                             title="remove actor">
                             <span class="glyphicon glyphicon-remove" aria-hidden="true"></span></a>
                     <% } %>
@@ -119,7 +119,7 @@
         
         <dt>Evidence Location</dt>
         <dd class="border-bottom">
-            <a href="#" class="<% if (editable) { %>editable-required<% } else { %>readonly<% } %>"
+            <a href="#" class="<% if (editable) { %>editable<% } else { %>readonly<% } %>"
                 data-name="provenance"
                 data-type="text" data-pk="<%=id%>"
                 data-params="{csrfmiddlewaretoken:'<%=csrf_token%>'}" 
@@ -156,21 +156,21 @@
             <dd>  
                 <ul class="additional-questions">
                     <% if (!place) { %> 
-                        <li class="footprint-place-container">
+                        <li>
                             <span class="glyphicon glyphicon-question-sign" aria-hidden="true"></span>
-                            <a href="#" class="<% if (editable) { %>editable-place<% } %> do-you-know persistant" data-name="place"
-                                data-type="place" data-pk="<%=id%>" data-value=""
-                                data-params="{csrfmiddlewaretoken:'<%=csrf_token%>'}" 
-                                data-url="/footprint/place/<%=id%>/add/">the place where the footprint occurred?</a>
+                            <a href="#" class="<% if (editable) { %>editable-place<% } %> do-you-know persistant"
+                                data-name="place" data-pk="<%=id%>" data-type="place"
+                                data-params="{csrfmiddlewaretoken:'<%=csrf_token%>',parent_id:<%=id%>,parent_model:'footprint'}"
+                                data-url="/place/add/">the place where the footprint occurred?</a>
                         </li>
                     <% } %>
                     <% if (!associated_date) { %> 
-                        <li class="footprint-date-container"><span class="glyphicon glyphicon-question-sign" aria-hidden="true"></span>
+                        <li><span class="glyphicon glyphicon-question-sign" aria-hidden="true"></span>
                         <a href="#" class="<% if (editable) { %>editable<% } %> do-you-know persistant editable-refresh"
-                            data-name="associated_date"
-                            data-type="text" data-pk="<%=id%>"
-                            data-params="{csrfmiddlewaretoken:'<%=csrf_token%>'}" data-value=""
-                            data-url="/footprint/date/<%=id%>/">the date when the footprint occurred?</a>
+                            data-name="date_string" data-type="text" data-pk="<%=id%>"
+                            data-value=""
+                            data-params="{csrfmiddlewaretoken:'<%=csrf_token%>',parent_id:<%=id%>,parent_model:'footprint',attr:'associated_date'}"
+                            data-url="/date/add/">the date when the footprint occurred?</a>
                         </li>
                     <% } %>
                     <% if (language.length < 1) { %> 
@@ -182,13 +182,13 @@
                             data-url="/api/footprint/<%=id%>/">the language(s) of the footprint?</a>
                         </li>
                     <% } %>
-                    <li class="fixed"><span class="glyphicon glyphicon-question-sign" aria-hidden="true"></span>
-                        <a href="#" class="<% if (editable) { %>editable-actor<% } %> do-you-know persistant" data-name="actor"
-                            data-template="#xeditable-actor-form" 
-                            data-type="actor" data-pk="<%=id%>" data-value=""
-                            data-params="{csrfmiddlewaretoken:'<%=csrf_token%>'}" 
-                            data-url="/footprint/actor/<%=id%>/add/">people related to this footprint, e.g. sellers, owners, curators?</a>
-                    </li>
+                        <li class="fixed"><span class="glyphicon glyphicon-question-sign" aria-hidden="true"></span>
+                            <a href="#" class="<% if (editable) { %>editable-actor<% } %> do-you-know persistant"
+                                data-name="actor" data-template="#xeditable-actor-form" 
+                                data-type="actor" data-pk="<%=id%>" data-value=""
+                                data-params="{csrfmiddlewaretoken:'<%=csrf_token%>',parent_id:<%=id%>,parent_model:'footprint'}" 
+                                data-url="/actor/add/">people related to this footprint, e.g. sellers, owners, curators?</a>
+                        </li>
                     <% if (medium_description.length < 1) { %> 
                         <li><span class="glyphicon glyphicon-question-sign" aria-hidden="true"></span>
                             <a href="#" class="<% if (editable) { %>editable<% } %> do-you-know persistant"

--- a/footprints/templates/clientside/footprint.html
+++ b/footprints/templates/clientside/footprint.html
@@ -15,58 +15,141 @@
         <% if (associated_date) { %>
             <dt>Footprint Date</dt>
             <dd class="border-bottom">
-                <a href="#" class="<% if (editable) { %>editable<% } else { %>readonly<% } %>"
-                 data-attribute-name="associated_date" data-name="edtf_format"
+                <a href="#" class="<% if (editable) { %>editable-required<% } else { %>readonly<% } %>"
+                 data-name="edtf_format"
                  data-type="text" data-pk="<%=associated_date.id%>"
                  data-params="{csrfmiddlewaretoken:'<%=csrf_token%>'}"
                  data-url="/api/edtf/<%=associated_date.id%>/">
                     <%=associated_date.edtf_format%>
                 </a>
-           </dd>
-       <% } %>
-       <% if (place) { %>
-           <dt>Footprint Place</dt>
-           <dd class="border-bottom footprint-place">
-               <span><%=place.display_title%></span>
-               <div class="pull-right">
-                   <% if (editable) { %>
-                       <a href="#" class="remove-related"
-                           data-params="{csrfmiddlewaretoken:'<%=csrf_token%>'}" 
-                           data-url="/footprint/place/<%=id%>/remove/<%=place.id%>/"
-                           title="remove place">
-                           <span class="glyphicon glyphicon-remove" aria-hidden="true"></span>
-                       </a>
-                   <% } %>
-                   &nbsp;
-                   <a href="/place/<%=place.id%>/" title="see details" class="foreign-key">
-                       <span class="glyphicon glyphicon-link" aria-hidden="true"></span>
-                   </a>
-               </div>
-               <div class="clearfix"></div>
-               <div class="footprint-map"
-                   data-latitude="<%=place.latitude%>"
-                   data-longitude="<%=place.longitude%>"
-                   data-title="<%=place.display_title%>">
-               </div>
-           </dd>
-       <% } %>
-       <% if (language.length > 0) { %>
-           <dt>Footprint Language</dt>
-           <dd class="border-bottom">
-               <a href="#" class="<% if (editable) { %>editable-language<% } else { %>readonly<% } %>"
-                   data-attribute-name="language" data-name="language"
-                   data-type="select2" data-pk="<%=id%>"
-                   data-value="[<% for (var i=0; i < language.length; i++) { %><%=language[i].id%><% if (i < language.length-1) { %> ,<% } }%>]"
-                   data-params="{csrfmiddlewaretoken:'<%=csrf_token%>'}"
-                   data-url="/api/footprint/<%=id%>/">
-                   <% for (var i=0; i < language.length; i++) { %> 
-                       <%= language[i].name %><% if (i < language.length-1) { %> , <% } %>
-                   <% } %>
-               </a>
-           </dd>
-       <% } %>
+            </dd>
+        <% } %>
+        <% if (place) { %>
+            <dt>Footprint Place</dt>
+            <dd class="border-bottom footprint-place">
+                <span><%=place.display_title%></span>
+                <div class="pull-right">
+                    <% if (editable) { %>
+                        <a href="#" class="remove-related"
+                            data-params="{csrfmiddlewaretoken:'<%=csrf_token%>'}" 
+                            data-url="/footprint/place/<%=id%>/remove/<%=place.id%>/"
+                            title="remove place">
+                            <span class="glyphicon glyphicon-remove" aria-hidden="true"></span>
+                        </a>
+                    <% } %>
+                    &nbsp;
+                    <a href="/place/<%=place.id%>/" title="see details" class="foreign-key">
+                        <span class="glyphicon glyphicon-link" aria-hidden="true"></span>
+                    </a>
+                </div>
+                <div class="clearfix"></div>
+                <div class="footprint-map"
+                    data-latitude="<%=place.latitude%>"
+                    data-longitude="<%=place.longitude%>"
+                    data-title="<%=place.display_title%>">
+                </div>
+            </dd>
+        <% } %>
+        <% if (language.length > 0) { %>
+            <dt>Footprint Language</dt>
+            <dd class="border-bottom">
+                <a href="#" class="<% if (editable) { %>editable-language<% } else { %>readonly<% } %>"
+                    data-name="language"
+                    data-type="select2" data-pk="<%=id%>"
+                    data-value="[<% for (var i=0; i < language.length; i++) { %><%=language[i].id%><% if (i < language.length-1) { %> ,<% } }%>]"
+                    data-params="{csrfmiddlewaretoken:'<%=csrf_token%>'}"
+                    data-url="/api/footprint/<%=id%>/">
+                    <% for (var i=0; i < language.length; i++) { %> 
+                        <%= language[i].name %><% if (i < language.length-1) { %> , <% } %>
+                    <% } %>
+                </a>
+            </dd>
+        <% } %>
+        <dt title="the written work's title exactly as it appears in the of evidence.">Footprint Title Display<br /></dt>
+        <dd class="border-bottom">
+            <a href="#" class="<% if (editable) { %>editable-required<% } else { %>readonly<% } %>"
+                data-name="title"
+                data-type="text" data-pk="<%=id%>"
+                data-params="{csrfmiddlewaretoken:'<%=csrf_token%>'}" 
+                data-url="/api/footprint/<%=id%>/"><%=title%></a>
+        </dd>
+        <% for (var i=0; i < actor.length; i++) { %> 
+            <dt><%=actor[i].role.name%></dt>
+            <dd class="border-bottom">
+                <span><%=actor[i].person.name%><% if (actor[i].alias) { %>  as <%=actor[i].alias%> <% } %></span> 
+                <div class="pull-right">
+                    <% if (editable) { %>
+                        <a href="#" class="remove-related"
+                            data-params="{csrfmiddlewaretoken:'<%=csrf_token%>'}" 
+                            data-url="/footprint/actor/<%=id%>/remove/<%=actor[i].id%>/"
+                            title="remove actor">
+                            <span class="glyphicon glyphicon-remove" aria-hidden="true"></span></a>
+                    <% } %>
+                    &nbsp;
+                    <a href="/person/<%=actor[i].person.id%>/" title="see details" class="foreign-key">
+                        <span class="glyphicon glyphicon-link" aria-hidden="true"></span>
+                    </a>
+                </div>
+            </dd>
+        <% } %> 
     </dl>
     
+    <dl class="dl-horizontal">
+        <dt>Evidence Type</dt>
+        <dd class="border-bottom">
+            <a href="#" class="<% if (editable) { %>editable-medium<% } else { %>readonly<% } %>"
+                data-name="medium"
+                data-type="select2" data-pk="<%=id%>"
+                data-value="<%=medium%>"
+                data-params="{csrfmiddlewaretoken:'<%=csrf_token%>'}"
+                data-url="/api/footprint/<%=id%>/"><%=medium%>
+            </a>
+        </dd>
+        
+        <% if (medium_description.length > 0) { %>
+            <dt>Evidence Type Description</dt>
+            <dd class="border-bottom">
+                <a href="#" class="<% if (editable) { %>editable<% } else { %>readonly<% } %>"
+                    data-name="medium_description"
+                    data-type="text" data-pk="<%=id%>"
+                    data-params="{csrfmiddlewaretoken:'<%=csrf_token%>'}" 
+                    data-url="/api/footprint/<%=id%>/"><%=medium_description%></a>
+             </dd>
+        <% } %>
+        
+        <dt>Evidence Location</dt>
+        <dd class="border-bottom">
+            <a href="#" class="<% if (editable) { %>editable-required<% } else { %>readonly<% } %>"
+                data-name="provenance"
+                data-type="text" data-pk="<%=id%>"
+                data-params="{csrfmiddlewaretoken:'<%=csrf_token%>'}" 
+                data-url="/api/footprint/<%=id%>/"><%=provenance%></a>
+        </dd>
+
+        <% if (call_number.length > 0) { %>
+            <dt>Evidence Call Number</dt>
+            <dd class="border-bottom">
+                <a href="#" class="<% if (editable) { %>editable<% } else { %>readonly<% } %>"
+                    data-name="call_number"
+                    data-type="text" data-pk="<%=id%>"
+                    data-params="{csrfmiddlewaretoken:'<%=csrf_token%>'}" 
+                    data-url="/api/footprint/<%=id%>/"><%=call_number%></a>
+            </dd>
+        <% } %>
+
+        <% if (notes.length > 0) { %>
+            <dt>Notes</dt>
+            <dd class="border-bottom">
+                <a href="#" class="<% if (editable) { %>editable<% } else { %>readonly<% } %>"
+                    data-name="notes"
+                    data-type="textarea" data-pk="<%=id%>"
+                    data-params="{csrfmiddlewaretoken:'<%=csrf_token%>'}" 
+                    data-url="/api/footprint/<%=id%>/"><%=notes%></a>
+            </dd>
+        <% } %>
+    </dl>
+    
+    <!-- FOOTPRINT - DO YOU KNOW -->
     <% if (editable) { %>
         <dl class="dl-horizontal">
             <dt>Do you know...</dt>
@@ -90,236 +173,15 @@
                             data-url="/footprint/date/<%=id%>/">the date when the footprint occurred?</a>
                         </li>
                     <% } %>
-                 </ul>    
-             </dd>
-         </dl>
-    <% } %>
-
-{% comment %} 
-    <dl class="dl-horizontal">
-    <div class="description-list" <% if (language.count < 1) { %> style="display: none"<% } %>>
-        <dt>Footprint Language</dt>
-        <dd class="border-bottom">
-            <a href="#" class="<% if (editable) { %>editable-language<% } else { %>readonly<% } %>"
-                data-attribute-name="language" data-name="language"
-                data-type="select2" data-pk="<%=id%>"
-                data-value="[{% for language in language.all) { %> {{language.id}}<% if (not forloop.last) { %> ,<% } %>{% endfor) { %> ]"
-                data-params="{csrfmiddlewaretoken:'<%=csrf_token%>'}"
-                data-url="/api/footprint/<%=id%>/">
-                {% for language in language.all) { %> 
-                    {{language.name}}<% if (not forloop.last) { %> , <% } %>
-                {% endfor) { %> 
-            </a>
-        </dd>
-    </div>
-    {% ifnotequal title display_title) { %> 
-    <div class="description-list" <% if (not title) { %> style="display: none"<% } %>>
-        <dt title="the written work's title exactly as it appears in the of evidence.">Footprint Title Display<br /></dt>
-        <dd class="border-bottom">
-            <a href="#" class="<% if (editable) { %>editable<% } else { %>readonly<% } %>"
-                data-attribute-name="title" data-name="title"
-                data-type="text" data-pk="<%=id%>"
-                data-params="{csrfmiddlewaretoken:'<%=csrf_token%>'}" 
-                data-url="/api/footprint/<%=id%>/">{{title}}</a>
-        </dd>
-    </div>
-    {% endifnotequal) { %> 
-    
-    <div class="actor-list">
-        {% for actor in actor.all) { %> 
-            <dt>{{actor.role.name}}</dt>
-            <dd class="border-bottom">
-                <span>{{actor.person.name}}<% if (actor.alias) { %>  as {{actor.alias}} <% } %></span> 
-                <div class="pull-right">
-                    <% if (editable) { %>
-                    <a href="#" class="remove-related"
-                        data-params="{csrfmiddlewaretoken:'<%=csrf_token%>'}" 
-                        data-url="/footprint/actor/<%=id%>/remove/{{actor.id}}/"
-                        title="remove actor">
-                        <span class="glyphicon glyphicon-remove" aria-hidden="true"></span></a>
-                    <% } %>
-                    &nbsp;
-                    <a href="/person/{{actor.person.id}}/" title="see details" class="foreign-key">
-                        <span class="glyphicon glyphicon-link" aria-hidden="true"></span>
-                    </a>
-                </div>
-            </dd>
-        {% endfor) { %> 
-   </div>
-</dl>    
-    </div>
-</div>
-
-    
-    {% for media in digital_object.all) { %> 
-        <img src="{{media.file.url}}"></img>
-    {% endfor) { %> 
-    <div class="evidence-container">
-        <dl class="dl-horizontal">
-            <div class="footprint-place footprint-place-container" <% if (not place) { %> style="display: none"<% } %>>
-                <dt>Footprint Place</dt>
-                <dd class="border-bottom footprint-place">
-                    <span>{{place}}</span>
-                    <div class="pull-right">
-                        <% if (editable) { %>
-                            <a href="#" class="remove-related"
-                                data-params="{csrfmiddlewaretoken:'<%=csrf_token%>'}" 
-                                data-url="/footprint/place/<%=id%>/remove/{{place.id}}/"
-                                title="remove place">
-                                <span class="glyphicon glyphicon-remove" aria-hidden="true"></span>
-                            </a>
-                        <% } %>
-                        &nbsp;
-                        <a href="/place/{{place.id}}/" title="see details" class="foreign-key">
-                            <span class="glyphicon glyphicon-link" aria-hidden="true"></span>
-                        </a>
-                    </div>
-                    <div class="clearfix"></div>
-                    <div class="footprint-map"
-                        data-latitude="{{place.position.latitude}}"
-                        data-longitude="{{place.position.longitude}}"
-                        data-title="{{place}}">
-                    </div>
-                </dd>
-            </div>
-            <div class="description-list" <% if (language.count < 1) { %> style="display: none"<% } %>>
-                <dt>Footprint Language</dt>
-                <dd class="border-bottom">
-                    <a href="#" class="<% if (editable) { %>editable-language<% } else { %>readonly<% } %>"
-                        data-attribute-name="language" data-name="language"
-                        data-type="select2" data-pk="<%=id%>"
-                        data-value="[{% for language in language.all) { %> {{language.id}}<% if (not forloop.last) { %> ,<% } %>{% endfor) { %> ]"
-                        data-params="{csrfmiddlewaretoken:'<%=csrf_token%>'}"
-                        data-url="/api/footprint/<%=id%>/">
-                        {% for language in language.all) { %> 
-                            {{language.name}}<% if (not forloop.last) { %> , <% } %>
-                        {% endfor) { %> 
-                    </a>
-                </dd>
-            </div>
-            {% ifnotequal title display_title) { %> 
-            <div class="description-list" <% if (not title) { %> style="display: none"<% } %>>
-                <dt title="the written work's title exactly as it appears in the of evidence.">Footprint Title Display<br /></dt>
-                <dd class="border-bottom">
-                    <a href="#" class="<% if (editable) { %>editable<% } else { %>readonly<% } %>"
-                        data-attribute-name="title" data-name="title"
-                        data-type="text" data-pk="<%=id%>"
-                        data-params="{csrfmiddlewaretoken:'<%=csrf_token%>'}" 
-                        data-url="/api/footprint/<%=id%>/">{{title}}</a>
-                </dd>
-            </div>
-            {% endifnotequal) { %> 
-            
-            <div class="actor-list">
-                {% for actor in actor.all) { %> 
-                    <dt>{{actor.role.name}}</dt>
-                    <dd class="border-bottom">
-                        <span>{{actor.person.name}}<% if (actor.alias) { %>  as {{actor.alias}} <% } %></span> 
-                        <div class="pull-right">
-                            <% if (editable) { %>
-                            <a href="#" class="remove-related"
-                                data-params="{csrfmiddlewaretoken:'<%=csrf_token%>'}" 
-                                data-url="/footprint/actor/<%=id%>/remove/{{actor.id}}/"
-                                title="remove actor">
-                                <span class="glyphicon glyphicon-remove" aria-hidden="true"></span></a>
-                            <% } %>
-                            &nbsp;
-                            <a href="/person/{{actor.person.id}}/" title="see details" class="foreign-key">
-                                <span class="glyphicon glyphicon-link" aria-hidden="true"></span>
-                            </a>
-                        </div>
-                    </dd>
-                {% endfor) { %> 
-           </div>
-        </dl>
-        <dl class="dl-horizontal">
-            <div class="evidence-type-container">
-            <dt>Evidence Type</dt>
-            <dd class="border-bottom">
-                <a href="#" class="<% if (editable) { %>editable-medium<% } else { %>readonly<% } %>"
-                    data-attribute-name="medium" data-name="medium"
-                    data-type="select2" data-pk="<%=id%>"
-                    data-value="{{medium}}"
-                    data-params="{csrfmiddlewaretoken:'<%=csrf_token%>'}"
-                    data-url="/api/footprint/<%=id%>/">{{medium}}
-                </a>
-            </dd>
-            </div>
-            <div class="description-list"
-                <% if (medium_description == None or medium_description == ''%}style="display: none"<% } %>>
-                <dt>Evidence Description</dt>
-                <dd class="border-bottom">
-                    <a href="#" class="<% if (editable) { %>editable<% } else { %>readonly<% } %>"
-                        data-attribute-name="medium_description" data-name="medium_description"
-                        data-type="text" data-pk="<%=id%>"
-                        data-params="{csrfmiddlewaretoken:'<%=csrf_token%>'}" 
-                        data-url="/api/footprint/<%=id%>/">{{medium_description}}</a>
-                </dd>
-            </div>
-            <div class="evidence-location-container">
-                <dt>Evidence Location</dt>
-                <dd class="border-bottom">
-                    <a href="#" class="<% if (editable) { %>editable<% } else { %>readonly<% } %>"
-                        data-attribute-name="provenance" data-name="provenance"
-                        data-type="text" data-pk="<%=id%>"
-                        data-params="{csrfmiddlewaretoken:'<%=csrf_token%>'}" 
-                        data-url="/api/footprint/<%=id%>/">{{provenance}}</a>
-                </dd>
-            </div>
-            <div class="description-list" <% if (call_number == None or call_number == '') { %> style="display: none"<% } %>>
-                <dt>Evidence Call Number</dt>
-                <dd class="border-bottom">
-                    <a href="#" class="<% if (editable) { %>editable<% } else { %>readonly<% } %>"
-                        data-attribute-name="call_number"  data-name="call_number"
-                        data-type="text" data-pk="<%=id%>"
-                        data-params="{csrfmiddlewaretoken:'<%=csrf_token%>'}" 
-                        data-url="/api/footprint/<%=id%>/">{{call_number}}</a>
-                </dd>
-            </div>                        
-            <div class="description-list" <% if (not notes) { %> style="display: none"<% } %>>
-                <dt>Notes</dt>
-                <dd class="border-bottom">
-                    <a href="#" class="<% if (editable) { %>editable<% } else { %>readonly<% } %>"
-                        data-attribute-name="notes" data-name="notes"
-                        data-type="textarea" data-pk="<%=id%>"
-                        data-params="{csrfmiddlewaretoken:'<%=csrf_token%>'}" 
-                        data-url="/api/footprint/<%=id%>/">{{notes|safe}}</a>
-                </dd>
-            </div>
-        </dl>
-        <% if (editable) { %>
-        <dl class="dl-horizontal">
-            <dt>Do you know...</dt>
-            <dd>  
-                <ul class="additional-questions">
-                    <% if (not place) { %> 
-                        <li class="footprint-place-container">
-                            <span class="glyphicon glyphicon-question-sign" aria-hidden="true"></span>
-                            <a href="#" class="<% if (editable) { %>editable-place<% } %> do-you-know persistant" data-name="place"
-                                data-type="place" data-pk="<%=id%>" data-value=""
-                                data-params="{csrfmiddlewaretoken:'<%=csrf_token%>'}" 
-                                data-url="/footprint/place/<%=id%>/add/">the place where the footprint occurred?</a>
-                        </li>
-                    <% } %>
-                    <% if (not associated_date) { %> 
-                        <li class="footprint-date-container"><span class="glyphicon glyphicon-question-sign" aria-hidden="true"></span>
-                        <a href="#" class="<% if (editable) { %>editable editable-date<% } %> do-you-know persistant"
-                            data-name="associated_date"
-                            data-type="text" data-pk="<%=id%>"
-                            data-params="{csrfmiddlewaretoken:'<%=csrf_token%>'}" data-value=""
-                            data-url="/footprint/date/<%=id%>/">the date when the footprint occurred?</a>
-                        </li>
-                    <% } %>
-                    <% if (language.count < 1) { %> 
+                    <% if (language.length < 1) { %> 
                         <li><span class="glyphicon glyphicon-question-sign" aria-hidden="true"></span>
                             <a href="#" class="<% if (editable) { %>editable-language<% } %> do-you-know persistant"
                                 data-name="language"
                                 data-type="select2" data-pk="<%=id%>" data-value=""
                                 data-params="{csrfmiddlewaretoken:'<%=csrf_token%>'}" 
-                                data-url="/api/footprint/<%=id%>/">the language(s) of the footprint?</a>
+                            data-url="/api/footprint/<%=id%>/">the language(s) of the footprint?</a>
                         </li>
                     <% } %>
-
                     <li class="fixed"><span class="glyphicon glyphicon-question-sign" aria-hidden="true"></span>
                         <a href="#" class="<% if (editable) { %>editable-actor<% } %> do-you-know persistant" data-name="actor"
                             data-template="#xeditable-actor-form" 
@@ -327,8 +189,7 @@
                             data-params="{csrfmiddlewaretoken:'<%=csrf_token%>'}" 
                             data-url="/footprint/actor/<%=id%>/add/">people related to this footprint, e.g. sellers, owners, curators?</a>
                     </li>
-
-                    <% if (medium_description == None or medium_description == '') { %> 
+                    <% if (medium_description.length < 1) { %> 
                         <li><span class="glyphicon glyphicon-question-sign" aria-hidden="true"></span>
                             <a href="#" class="<% if (editable) { %>editable<% } %> do-you-know persistant"
                                 data-name="medium_description" data-value=""                                         
@@ -337,17 +198,15 @@
                                 data-url="/api/footprint/<%=id%>/">details about the evidence type, e.g. a catalog title?</a>
                         </li>
                     <% } %>
-
-                    <% if (call_number == None or call_number == '') { %> 
+                    <% if (call_number.length < 1) { %> 
                         <li><span class="glyphicon glyphicon-question-sign" aria-hidden="true"></span>
-                        <a href="#" class="<% if (editable) { %>editable<% } %> do-you-know persistant" data-name="call_number"
-                            data-type="text" data-pk="<%=id%>"
-                            data-params="{csrfmiddlewaretoken:'<%=csrf_token%>'}" 
-                            data-value=""
-                            data-url="/api/footprint/<%=id%>/">the call number of the evidence?</a>
+                            <a href="#" class="<% if (editable) { %>editable<% } %> do-you-know persistant" data-name="call_number"
+                                data-type="text" data-pk="<%=id%>"
+                                data-params="{csrfmiddlewaretoken:'<%=csrf_token%>'}" 
+                                data-url="/api/footprint/<%=id%>/">the call number of the evidence?</a>
                         </li>
                     <% } %>
-                    <% if (!notes) { %> 
+                    <% if (notes.length < 1) { %> 
                         <li><span class="glyphicon glyphicon-question-sign" aria-hidden="true"></span>
                             <a href="#" class="editable do-you-know persistant" data-name="notes"
                                data-type="textarea" data-pk="<%=id%>" data-value=""
@@ -355,47 +214,8 @@
                                data-url="/api/footprint/<%=id%>/">any additional notes, clarifications, deductions or oddities?</a>
                         </li>
                     <% } %>
-                </ul>
+                </ul>    
             </dd>
         </dl>
-        <% } %>
-    </div>
-</div>
-{% endcomment %} 
-</script>
-
-<script type="text-template" id="actor-display-template">
-    <dt><%=actor.role.name%></dt>
-    <dd class="border-bottom">
-        <span><%=actor.person.name %><% if (actor.alias.length > 0) { %> as <%=actor.alias%> <% } %></span> 
-        <div class="pull-right">
-            <a href="#" class="remove-related"
-                data-params="{csrfmiddlewaretoken:'<%=csrf_token%>'}"
-                data-url="/<%=object.type%>/actor/<%=object.id%>/remove/<%=actor.id%>/"
-                title="remove actor">
-                <span class="glyphicon glyphicon-remove" aria-hidden="true"></span></a>
-            &nbsp;
-            <a href="/person/<%=actor.person.id%>/" title="see details" class="foreign-key">
-                <span class="glyphicon glyphicon-link" aria-hidden="true"></span>
-            </a>
-        </div>
-    </dd>
-</script>
-
-<script type="text/template" id="place-display-template">
-    <dt>Footprint Place</dt>
-    <dd class="border-bottom footprint-place">
-        <span><%= place.description %></span>
-        <div class="pull-right">
-            <a href="#" class="remove-related"
-                data-params="{csrfmiddlewaretoken:'<%=csrf_token%>'}" 
-                data-url="/footprint/place/<%=footprint_id%>/remove/<%= place.id%>/"
-                title="remove place">
-                <span class="glyphicon glyphicon-remove" aria-hidden="true"></span></a>
-            &nbsp;
-            <a href="/place/<%=place.id%>/" title="see details" class="foreign-key">
-                <span class="glyphicon glyphicon-link" aria-hidden="true"></span>
-            </a>
-        </div>
-    </dd>
+    <% } %>
 </script>

--- a/footprints/templates/clientside/footprint.html
+++ b/footprints/templates/clientside/footprint.html
@@ -1,0 +1,401 @@
+<script type="text/template" id="footprint-detail-template">
+    <h1>
+        <img class="pull-left" src="<%=static_url%>img/footprint.png" />
+        <span class="pull-left object-title" data-name='display-title'><%=title%></span>
+        <div class="clearfix"></div>
+    </h1>
+    <div class="breadcrumb">A FOOTPRINT</div>
+    <% if (narrative) { %>
+        <blockquote class="blockquote">
+            <%=narrative%>
+        </blockquote>
+    <% } %>
+
+    <dl class="dl-horizontal">
+        <% if (associated_date) { %>
+            <dt>Footprint Date</dt>
+            <dd class="border-bottom">
+                <a href="#" class="<% if (editable) { %>editable<% } else { %>readonly<% } %>"
+                 data-attribute-name="associated_date" data-name="edtf_format"
+                 data-type="text" data-pk="<%=associated_date.id%>"
+                 data-params="{csrfmiddlewaretoken:'<%=csrf_token%>'}"
+                 data-url="/api/edtf/<%=associated_date.id%>/">
+                    <%=associated_date.edtf_format%>
+                </a>
+           </dd>
+       <% } %>
+       <% if (place) { %>
+           <dt>Footprint Place</dt>
+           <dd class="border-bottom footprint-place">
+               <span><%=place.display_title%></span>
+               <div class="pull-right">
+                   <% if (editable) { %>
+                       <a href="#" class="remove-related"
+                           data-params="{csrfmiddlewaretoken:'<%=csrf_token%>'}" 
+                           data-url="/footprint/place/<%=id%>/remove/<%=place.id%>/"
+                           title="remove place">
+                           <span class="glyphicon glyphicon-remove" aria-hidden="true"></span>
+                       </a>
+                   <% } %>
+                   &nbsp;
+                   <a href="/place/<%=place.id%>/" title="see details" class="foreign-key">
+                       <span class="glyphicon glyphicon-link" aria-hidden="true"></span>
+                   </a>
+               </div>
+               <div class="clearfix"></div>
+               <div class="footprint-map"
+                   data-latitude="<%=place.latitude%>"
+                   data-longitude="<%=place.longitude%>"
+                   data-title="<%=place.display_title%>">
+               </div>
+           </dd>
+       <% } %>
+       <% if (language.length > 0) { %>
+           <dt>Footprint Language</dt>
+           <dd class="border-bottom">
+               <a href="#" class="<% if (editable) { %>editable-language<% } else { %>readonly<% } %>"
+                   data-attribute-name="language" data-name="language"
+                   data-type="select2" data-pk="<%=id%>"
+                   data-value="[<% for (var i=0; i < language.length; i++) { %><%=language[i].id%><% if (i < language.length-1) { %> ,<% } }%>]"
+                   data-params="{csrfmiddlewaretoken:'<%=csrf_token%>'}"
+                   data-url="/api/footprint/<%=id%>/">
+                   <% for (var i=0; i < language.length; i++) { %> 
+                       <%= language[i].name %><% if (i < language.length-1) { %> , <% } %>
+                   <% } %>
+               </a>
+           </dd>
+       <% } %>
+    </dl>
+    
+    <% if (editable) { %>
+        <dl class="dl-horizontal">
+            <dt>Do you know...</dt>
+            <dd>  
+                <ul class="additional-questions">
+                    <% if (!place) { %> 
+                        <li class="footprint-place-container">
+                            <span class="glyphicon glyphicon-question-sign" aria-hidden="true"></span>
+                            <a href="#" class="<% if (editable) { %>editable-place<% } %> do-you-know persistant" data-name="place"
+                                data-type="place" data-pk="<%=id%>" data-value=""
+                                data-params="{csrfmiddlewaretoken:'<%=csrf_token%>'}" 
+                                data-url="/footprint/place/<%=id%>/add/">the place where the footprint occurred?</a>
+                        </li>
+                    <% } %>
+                    <% if (!associated_date) { %> 
+                        <li class="footprint-date-container"><span class="glyphicon glyphicon-question-sign" aria-hidden="true"></span>
+                        <a href="#" class="<% if (editable) { %>editable<% } %> do-you-know persistant editable-refresh"
+                            data-name="associated_date"
+                            data-type="text" data-pk="<%=id%>"
+                            data-params="{csrfmiddlewaretoken:'<%=csrf_token%>'}" data-value=""
+                            data-url="/footprint/date/<%=id%>/">the date when the footprint occurred?</a>
+                        </li>
+                    <% } %>
+                 </ul>    
+             </dd>
+         </dl>
+    <% } %>
+
+{% comment %} 
+    <dl class="dl-horizontal">
+    <div class="description-list" <% if (language.count < 1) { %> style="display: none"<% } %>>
+        <dt>Footprint Language</dt>
+        <dd class="border-bottom">
+            <a href="#" class="<% if (editable) { %>editable-language<% } else { %>readonly<% } %>"
+                data-attribute-name="language" data-name="language"
+                data-type="select2" data-pk="<%=id%>"
+                data-value="[{% for language in language.all) { %> {{language.id}}<% if (not forloop.last) { %> ,<% } %>{% endfor) { %> ]"
+                data-params="{csrfmiddlewaretoken:'<%=csrf_token%>'}"
+                data-url="/api/footprint/<%=id%>/">
+                {% for language in language.all) { %> 
+                    {{language.name}}<% if (not forloop.last) { %> , <% } %>
+                {% endfor) { %> 
+            </a>
+        </dd>
+    </div>
+    {% ifnotequal title display_title) { %> 
+    <div class="description-list" <% if (not title) { %> style="display: none"<% } %>>
+        <dt title="the written work's title exactly as it appears in the of evidence.">Footprint Title Display<br /></dt>
+        <dd class="border-bottom">
+            <a href="#" class="<% if (editable) { %>editable<% } else { %>readonly<% } %>"
+                data-attribute-name="title" data-name="title"
+                data-type="text" data-pk="<%=id%>"
+                data-params="{csrfmiddlewaretoken:'<%=csrf_token%>'}" 
+                data-url="/api/footprint/<%=id%>/">{{title}}</a>
+        </dd>
+    </div>
+    {% endifnotequal) { %> 
+    
+    <div class="actor-list">
+        {% for actor in actor.all) { %> 
+            <dt>{{actor.role.name}}</dt>
+            <dd class="border-bottom">
+                <span>{{actor.person.name}}<% if (actor.alias) { %>  as {{actor.alias}} <% } %></span> 
+                <div class="pull-right">
+                    <% if (editable) { %>
+                    <a href="#" class="remove-related"
+                        data-params="{csrfmiddlewaretoken:'<%=csrf_token%>'}" 
+                        data-url="/footprint/actor/<%=id%>/remove/{{actor.id}}/"
+                        title="remove actor">
+                        <span class="glyphicon glyphicon-remove" aria-hidden="true"></span></a>
+                    <% } %>
+                    &nbsp;
+                    <a href="/person/{{actor.person.id}}/" title="see details" class="foreign-key">
+                        <span class="glyphicon glyphicon-link" aria-hidden="true"></span>
+                    </a>
+                </div>
+            </dd>
+        {% endfor) { %> 
+   </div>
+</dl>    
+    </div>
+</div>
+
+    
+    {% for media in digital_object.all) { %> 
+        <img src="{{media.file.url}}"></img>
+    {% endfor) { %> 
+    <div class="evidence-container">
+        <dl class="dl-horizontal">
+            <div class="footprint-place footprint-place-container" <% if (not place) { %> style="display: none"<% } %>>
+                <dt>Footprint Place</dt>
+                <dd class="border-bottom footprint-place">
+                    <span>{{place}}</span>
+                    <div class="pull-right">
+                        <% if (editable) { %>
+                            <a href="#" class="remove-related"
+                                data-params="{csrfmiddlewaretoken:'<%=csrf_token%>'}" 
+                                data-url="/footprint/place/<%=id%>/remove/{{place.id}}/"
+                                title="remove place">
+                                <span class="glyphicon glyphicon-remove" aria-hidden="true"></span>
+                            </a>
+                        <% } %>
+                        &nbsp;
+                        <a href="/place/{{place.id}}/" title="see details" class="foreign-key">
+                            <span class="glyphicon glyphicon-link" aria-hidden="true"></span>
+                        </a>
+                    </div>
+                    <div class="clearfix"></div>
+                    <div class="footprint-map"
+                        data-latitude="{{place.position.latitude}}"
+                        data-longitude="{{place.position.longitude}}"
+                        data-title="{{place}}">
+                    </div>
+                </dd>
+            </div>
+            <div class="description-list" <% if (language.count < 1) { %> style="display: none"<% } %>>
+                <dt>Footprint Language</dt>
+                <dd class="border-bottom">
+                    <a href="#" class="<% if (editable) { %>editable-language<% } else { %>readonly<% } %>"
+                        data-attribute-name="language" data-name="language"
+                        data-type="select2" data-pk="<%=id%>"
+                        data-value="[{% for language in language.all) { %> {{language.id}}<% if (not forloop.last) { %> ,<% } %>{% endfor) { %> ]"
+                        data-params="{csrfmiddlewaretoken:'<%=csrf_token%>'}"
+                        data-url="/api/footprint/<%=id%>/">
+                        {% for language in language.all) { %> 
+                            {{language.name}}<% if (not forloop.last) { %> , <% } %>
+                        {% endfor) { %> 
+                    </a>
+                </dd>
+            </div>
+            {% ifnotequal title display_title) { %> 
+            <div class="description-list" <% if (not title) { %> style="display: none"<% } %>>
+                <dt title="the written work's title exactly as it appears in the of evidence.">Footprint Title Display<br /></dt>
+                <dd class="border-bottom">
+                    <a href="#" class="<% if (editable) { %>editable<% } else { %>readonly<% } %>"
+                        data-attribute-name="title" data-name="title"
+                        data-type="text" data-pk="<%=id%>"
+                        data-params="{csrfmiddlewaretoken:'<%=csrf_token%>'}" 
+                        data-url="/api/footprint/<%=id%>/">{{title}}</a>
+                </dd>
+            </div>
+            {% endifnotequal) { %> 
+            
+            <div class="actor-list">
+                {% for actor in actor.all) { %> 
+                    <dt>{{actor.role.name}}</dt>
+                    <dd class="border-bottom">
+                        <span>{{actor.person.name}}<% if (actor.alias) { %>  as {{actor.alias}} <% } %></span> 
+                        <div class="pull-right">
+                            <% if (editable) { %>
+                            <a href="#" class="remove-related"
+                                data-params="{csrfmiddlewaretoken:'<%=csrf_token%>'}" 
+                                data-url="/footprint/actor/<%=id%>/remove/{{actor.id}}/"
+                                title="remove actor">
+                                <span class="glyphicon glyphicon-remove" aria-hidden="true"></span></a>
+                            <% } %>
+                            &nbsp;
+                            <a href="/person/{{actor.person.id}}/" title="see details" class="foreign-key">
+                                <span class="glyphicon glyphicon-link" aria-hidden="true"></span>
+                            </a>
+                        </div>
+                    </dd>
+                {% endfor) { %> 
+           </div>
+        </dl>
+        <dl class="dl-horizontal">
+            <div class="evidence-type-container">
+            <dt>Evidence Type</dt>
+            <dd class="border-bottom">
+                <a href="#" class="<% if (editable) { %>editable-medium<% } else { %>readonly<% } %>"
+                    data-attribute-name="medium" data-name="medium"
+                    data-type="select2" data-pk="<%=id%>"
+                    data-value="{{medium}}"
+                    data-params="{csrfmiddlewaretoken:'<%=csrf_token%>'}"
+                    data-url="/api/footprint/<%=id%>/">{{medium}}
+                </a>
+            </dd>
+            </div>
+            <div class="description-list"
+                <% if (medium_description == None or medium_description == ''%}style="display: none"<% } %>>
+                <dt>Evidence Description</dt>
+                <dd class="border-bottom">
+                    <a href="#" class="<% if (editable) { %>editable<% } else { %>readonly<% } %>"
+                        data-attribute-name="medium_description" data-name="medium_description"
+                        data-type="text" data-pk="<%=id%>"
+                        data-params="{csrfmiddlewaretoken:'<%=csrf_token%>'}" 
+                        data-url="/api/footprint/<%=id%>/">{{medium_description}}</a>
+                </dd>
+            </div>
+            <div class="evidence-location-container">
+                <dt>Evidence Location</dt>
+                <dd class="border-bottom">
+                    <a href="#" class="<% if (editable) { %>editable<% } else { %>readonly<% } %>"
+                        data-attribute-name="provenance" data-name="provenance"
+                        data-type="text" data-pk="<%=id%>"
+                        data-params="{csrfmiddlewaretoken:'<%=csrf_token%>'}" 
+                        data-url="/api/footprint/<%=id%>/">{{provenance}}</a>
+                </dd>
+            </div>
+            <div class="description-list" <% if (call_number == None or call_number == '') { %> style="display: none"<% } %>>
+                <dt>Evidence Call Number</dt>
+                <dd class="border-bottom">
+                    <a href="#" class="<% if (editable) { %>editable<% } else { %>readonly<% } %>"
+                        data-attribute-name="call_number"  data-name="call_number"
+                        data-type="text" data-pk="<%=id%>"
+                        data-params="{csrfmiddlewaretoken:'<%=csrf_token%>'}" 
+                        data-url="/api/footprint/<%=id%>/">{{call_number}}</a>
+                </dd>
+            </div>                        
+            <div class="description-list" <% if (not notes) { %> style="display: none"<% } %>>
+                <dt>Notes</dt>
+                <dd class="border-bottom">
+                    <a href="#" class="<% if (editable) { %>editable<% } else { %>readonly<% } %>"
+                        data-attribute-name="notes" data-name="notes"
+                        data-type="textarea" data-pk="<%=id%>"
+                        data-params="{csrfmiddlewaretoken:'<%=csrf_token%>'}" 
+                        data-url="/api/footprint/<%=id%>/">{{notes|safe}}</a>
+                </dd>
+            </div>
+        </dl>
+        <% if (editable) { %>
+        <dl class="dl-horizontal">
+            <dt>Do you know...</dt>
+            <dd>  
+                <ul class="additional-questions">
+                    <% if (not place) { %> 
+                        <li class="footprint-place-container">
+                            <span class="glyphicon glyphicon-question-sign" aria-hidden="true"></span>
+                            <a href="#" class="<% if (editable) { %>editable-place<% } %> do-you-know persistant" data-name="place"
+                                data-type="place" data-pk="<%=id%>" data-value=""
+                                data-params="{csrfmiddlewaretoken:'<%=csrf_token%>'}" 
+                                data-url="/footprint/place/<%=id%>/add/">the place where the footprint occurred?</a>
+                        </li>
+                    <% } %>
+                    <% if (not associated_date) { %> 
+                        <li class="footprint-date-container"><span class="glyphicon glyphicon-question-sign" aria-hidden="true"></span>
+                        <a href="#" class="<% if (editable) { %>editable editable-date<% } %> do-you-know persistant"
+                            data-name="associated_date"
+                            data-type="text" data-pk="<%=id%>"
+                            data-params="{csrfmiddlewaretoken:'<%=csrf_token%>'}" data-value=""
+                            data-url="/footprint/date/<%=id%>/">the date when the footprint occurred?</a>
+                        </li>
+                    <% } %>
+                    <% if (language.count < 1) { %> 
+                        <li><span class="glyphicon glyphicon-question-sign" aria-hidden="true"></span>
+                            <a href="#" class="<% if (editable) { %>editable-language<% } %> do-you-know persistant"
+                                data-name="language"
+                                data-type="select2" data-pk="<%=id%>" data-value=""
+                                data-params="{csrfmiddlewaretoken:'<%=csrf_token%>'}" 
+                                data-url="/api/footprint/<%=id%>/">the language(s) of the footprint?</a>
+                        </li>
+                    <% } %>
+
+                    <li class="fixed"><span class="glyphicon glyphicon-question-sign" aria-hidden="true"></span>
+                        <a href="#" class="<% if (editable) { %>editable-actor<% } %> do-you-know persistant" data-name="actor"
+                            data-template="#xeditable-actor-form" 
+                            data-type="actor" data-pk="<%=id%>" data-value=""
+                            data-params="{csrfmiddlewaretoken:'<%=csrf_token%>'}" 
+                            data-url="/footprint/actor/<%=id%>/add/">people related to this footprint, e.g. sellers, owners, curators?</a>
+                    </li>
+
+                    <% if (medium_description == None or medium_description == '') { %> 
+                        <li><span class="glyphicon glyphicon-question-sign" aria-hidden="true"></span>
+                            <a href="#" class="<% if (editable) { %>editable<% } %> do-you-know persistant"
+                                data-name="medium_description" data-value=""                                         
+                                data-type="text" data-pk="<%=id%>"
+                                data-params="{csrfmiddlewaretoken:'<%=csrf_token%>'}"
+                                data-url="/api/footprint/<%=id%>/">details about the evidence type, e.g. a catalog title?</a>
+                        </li>
+                    <% } %>
+
+                    <% if (call_number == None or call_number == '') { %> 
+                        <li><span class="glyphicon glyphicon-question-sign" aria-hidden="true"></span>
+                        <a href="#" class="<% if (editable) { %>editable<% } %> do-you-know persistant" data-name="call_number"
+                            data-type="text" data-pk="<%=id%>"
+                            data-params="{csrfmiddlewaretoken:'<%=csrf_token%>'}" 
+                            data-value=""
+                            data-url="/api/footprint/<%=id%>/">the call number of the evidence?</a>
+                        </li>
+                    <% } %>
+                    <% if (!notes) { %> 
+                        <li><span class="glyphicon glyphicon-question-sign" aria-hidden="true"></span>
+                            <a href="#" class="editable do-you-know persistant" data-name="notes"
+                               data-type="textarea" data-pk="<%=id%>" data-value=""
+                               data-params="{csrfmiddlewaretoken:'<%=csrf_token%>'}"
+                               data-url="/api/footprint/<%=id%>/">any additional notes, clarifications, deductions or oddities?</a>
+                        </li>
+                    <% } %>
+                </ul>
+            </dd>
+        </dl>
+        <% } %>
+    </div>
+</div>
+{% endcomment %} 
+</script>
+
+<script type="text-template" id="actor-display-template">
+    <dt><%=actor.role.name%></dt>
+    <dd class="border-bottom">
+        <span><%=actor.person.name %><% if (actor.alias.length > 0) { %> as <%=actor.alias%> <% } %></span> 
+        <div class="pull-right">
+            <a href="#" class="remove-related"
+                data-params="{csrfmiddlewaretoken:'<%=csrf_token%>'}"
+                data-url="/<%=object.type%>/actor/<%=object.id%>/remove/<%=actor.id%>/"
+                title="remove actor">
+                <span class="glyphicon glyphicon-remove" aria-hidden="true"></span></a>
+            &nbsp;
+            <a href="/person/<%=actor.person.id%>/" title="see details" class="foreign-key">
+                <span class="glyphicon glyphicon-link" aria-hidden="true"></span>
+            </a>
+        </div>
+    </dd>
+</script>
+
+<script type="text/template" id="place-display-template">
+    <dt>Footprint Place</dt>
+    <dd class="border-bottom footprint-place">
+        <span><%= place.description %></span>
+        <div class="pull-right">
+            <a href="#" class="remove-related"
+                data-params="{csrfmiddlewaretoken:'<%=csrf_token%>'}" 
+                data-url="/footprint/place/<%=footprint_id%>/remove/<%= place.id%>/"
+                title="remove place">
+                <span class="glyphicon glyphicon-remove" aria-hidden="true"></span></a>
+            &nbsp;
+            <a href="/place/<%=place.id%>/" title="see details" class="foreign-key">
+                <span class="glyphicon glyphicon-link" aria-hidden="true"></span>
+            </a>
+        </div>
+    </dd>
+</script>

--- a/footprints/templates/clientside/footprint_book.html
+++ b/footprints/templates/clientside/footprint_book.html
@@ -1,19 +1,153 @@
 <script type="text/template" id="book-detail-template">
 <div class="breadcrumb">THE BOOK</div>
 <dl class="dl-horizontal">
+    <dt>Book Copy Identifier</dt><dd class="border-bottom"><%=id%>-<%=imprint.id%></dd>
     <% if (imprint.work.title.length > 0) { %>
         <dt>Title</dt>
-        <dd><a href="#" class="<% if (editable) { %>editable<% } else { %>readonly<% } %>"
+        <dd class="border-bottom"><a href="#" class="<% if (editable) { %>editable<% } else { %>readonly<% } %>"
                 data-attribute-name="title"  data-name="title"
                 data-type="text" data-pk="<%=imprint.work.id%>"
                 data-params="{csrfmiddlewaretoken:'<%=csrf_token%>'}"
                 data-url="/api/writtenwork/<%=imprint.work.id%>/">
                 <%=imprint.work.title%>
             </a>
+            <div class="pull-right">
+                <a href="/writtenwork/<%=imprint.work.id%>/" title="see details" class="foreign-key">
+                    <span class="glyphicon glyphicon-link" aria-hidden="true"></span>
+                </a>
+            </div>
+        </dd>
+    <% } %>
+
+    <% for (var i=0; i < imprint.work.actor.length; i++) { %> 
+        <dt><%=imprint.work.actor[i].role.name%></dt>
+        <dd class="border-bottom">
+            <span><%=imprint.work.actor[i].person.name%><% if (imprint.work.actor[i].alias) { %>  as <%=imprint.work.actor[i].alias%> <% } %></span> 
+            <div class="pull-right">
+                <% if (editable) { %>
+                    <a href="#" class="remove-related"
+                     data-params="{actor_id:'<%=imprint.work.actor[i].id%>',csrfmiddlewaretoken:'<%=csrf_token%>',parent_id:<%=imprint.work.id%>,parent_model:'writtenwork'}" 
+                     data-url="/remove/related/"
+                     title="remove author">
+                        <span class="glyphicon glyphicon-remove" aria-hidden="true"></span>
+                    </a>
+                <% } %>
+                &nbsp;
+                <a href="/person/<%=imprint.work.actor[i].person.id%>/" title="see details" class="foreign-key">
+                    <span class="glyphicon glyphicon-link" aria-hidden="true"></span>
+                </a>
+            </div>
+        </dd>
+    <% } %>
+    <% if (imprint.work.notes.length > 0) { %>
+        <dt>Notes</dt>
+        <dd class="border-bottom">
+            <a href="#" class="<% if (editable) { %>editable<% } else { %>readonly<% } %>"
+                data-attribute-name="notes" data-name="notes"
+                data-type="textarea" data-pk="<%=imprint.work.id%>"
+                data-params="{csrfmiddlewaretoken:'<%=csrf_token%>'}" 
+                data-url="/api/writtenwork/<%=imprint.work.id%>/"><%=imprint.work.notes%></a>
         </dd>
     <% } %>
 </dl>
 
+<dl class="dl-horizontal">
+    <% if (imprint.title && imprint.title.length > 0) { %>
+        <dt>Imprint Title</dt>
+        <dd class="border-bottom"><a href="#" class="<% if (editable) { %>editable<% } else { %>readonly<% } %>"
+             data-attribute-name="title"  data-name="title"
+             data-type="text" data-pk="<%=imprint.id%>"
+             data-params="{csrfmiddlewaretoken:'<%=csrf_token%>'}"
+             data-url="/api/imprint/<%=imprint.id%>/">
+                <%=imprint.title%>
+            </a>
+        </dd>
+    <% } %>
+    <% if (imprint.language.length > 0) { %>
+        <dt>Imprint Language</dt>
+        <dd class="border-bottom">
+            <a href="#" class="<% if (editable) { %>editable-language<% } else { %>readonly<% } %>"
+                data-name="language"
+                data-type="select2" data-pk="<%=imprint.id%>"
+                data-value="[<% for (var i=0; i < imprint.language.length; i++) { %><%=imprint.language[i].id%><% if (i < imprint.language.length-1) { %> ,<% } }%>]"
+                data-params="{csrfmiddlewaretoken:'<%=csrf_token%>'}"
+                data-url="/api/imprint/<%=imprint.id%>/">
+                <% for (var i=0; i < imprint.language.length; i++) { %> 
+                    <%= imprint.language[i].name %><% if (i < imprint.language.length-1) { %> , <% } %>
+                <% } %>
+            </a>
+        </dd>
+    <% } %>
+    <% if (imprint.date_of_publication) { %>
+        <dt>Publication Date</dt>
+        <dd class="border-bottom">
+            <a href="#" class="<% if (editable) { %>editable<% } else { %>readonly<% } %>"
+             data-name="edtf_format"
+             data-type="text" data-pk="<%=imprint.date_of_publication.id%>"
+             data-params="{csrfmiddlewaretoken:'<%=csrf_token%>'}"
+             data-url="/api/edtf/<%=imprint.date_of_publication.id%>/">
+                <%=imprint.date_of_publication.edtf_format%>
+            </a>
+        </dd>
+    <% } %>
+    <% if (imprint.place) { %>
+        <dt>Imprint Location</dt>
+        <dd class="border-bottom footprint-place">
+            <span><%=imprint.place.display_title%></span>
+            <div class="pull-right">
+                <% if (editable) { %>
+                    <a href="#" class="remove-related"
+                        data-params="{place_id:'<%=imprint.place.id%>',csrfmiddlewaretoken:'<%=csrf_token%>',parent_id:<%=imprint.id%>,parent_model:'imprint'}" 
+                        data-url="/remove/related/"
+                        title="remove place">
+                        <span class="glyphicon glyphicon-remove" aria-hidden="true"></span>
+                    </a>
+                <% } %>
+                &nbsp;
+                <a href="/place/<%=imprint.place.id%>/" title="see details" class="foreign-key">
+                    <span class="glyphicon glyphicon-link" aria-hidden="true"></span>
+                </a>
+            </div>
+            <div class="clearfix"></div>
+            <div class="footprint-map"
+                data-latitude="<%=imprint.place.latitude%>"
+                data-longitude="<%=imprint.place.longitude%>"
+                data-title="<%=imprint.place.display_title%>">
+            </div>
+        </dd>
+    <% } %>
+    <% for (var i=0; i < imprint.actor.length; i++) { %> 
+        <dt><%=imprint.actor[i].role.name%></dt>
+        <dd class="border-bottom">
+            <span><%=imprint.actor[i].person.name%><% if (imprint.actor[i].alias) { %>  as <%=imprint.actor[i].alias%> <% } %></span> 
+            <div class="pull-right">
+                <% if (editable) { %>
+                    <a href="#" class="remove-related"
+                     data-params="{actor_id:'<%=imprint.actor[i].id%>',csrfmiddlewaretoken:'<%=csrf_token%>',parent_id:<%=imprint.id%>,parent_model:'imprint'}" 
+                     data-url="/remove/related/"
+                     title="remove author">
+                        <span class="glyphicon glyphicon-remove" aria-hidden="true"></span>
+                    </a>
+                <% } %>
+                &nbsp;
+                <a href="/person/<%=imprint.actor[i].person.id%>/" title="see details" class="foreign-key">
+                    <span class="glyphicon glyphicon-link" aria-hidden="true"></span>
+                </a>
+            </div>
+        </dd>
+    <% } %>
+    <% if (imprint.notes && imprint.notes.length > 0) { %>
+        <dt>Imprint Notes</dt>
+        <dd class="border-bottom">
+            <a href="#" class="<% if (editable) { %>editable<% } else { %>readonly<% } %>"
+                data-attribute-name="notes" data-name="notes"
+                data-type="textarea" data-pk="<%=imprint.id%>"
+                data-params="{csrfmiddlewaretoken:'<%=csrf_token%>'}" 
+                data-url="/api/imprint/<%=imprint.id%>/"><%=imprint.notes%></a>
+        </dd>
+    <% } %>
+    
+</dl>
 
 <% if (editable) { %>
     <dl class="dl-horizontal">
@@ -27,6 +161,78 @@
                             data-name="title" data-type="text" data-pk="<%=imprint.work.id%>" data-value=""
                             data-params="{csrfmiddlewaretoken:'<%=csrf_token%>'}"
                             data-url="/api/writtenwork/<%=imprint.work.id%>/">the title of the written work?</a>
+                    </li>
+                <% } %>
+                <li class="fixed"><span class="glyphicon glyphicon-question-sign" aria-hidden="true"></span>
+                    <a href="#" class="<% if (editable) { %>editable-author<% } %> do-you-know persistant" data-name="actor"
+                        data-template="#xeditable-author-form"
+                        data-type="actor" data-pk="<%=imprint.work.id%>" data-value=""
+                        data-params="{csrfmiddlewaretoken:'<%=csrf_token%>',parent_id:<%=imprint.work.id%>,parent_model:'writtenwork'}" 
+                        data-url="/actor/add/">the author(s) of the written work?</a>
+                </li>
+                
+                <% if (imprint.work.notes.length < 1) { %>
+                    <li><span class="glyphicon glyphicon-question-sign" aria-hidden="true"></span>
+                        <a href="#" class="editable do-you-know persistant" data-name="notes"
+                            data-type="textarea" data-pk="<%=imprint.work.id%>" data-value=""
+                            data-params="{csrfmiddlewaretoken:'<%=csrf_token%>'}"
+                            data-url="/api/writtenwork/<%=imprint.work.id%>/">any additional notes about the written work?</a>
+                    </li>
+                <% } %>
+                
+                <% if (!imprint.title || imprint.title.length < 1) { %>
+                    <li>
+                        <span class="glyphicon glyphicon-question-sign" aria-hidden="true"></span>
+                        <a href="#" class="<% if (editable) { %>editable<% } %> do-you-know persistant"
+                            data-name="title" data-type="text" data-pk="<%=imprint.id%>" data-value=""
+                            data-params="{csrfmiddlewaretoken:'<%=csrf_token%>'}"
+                            data-url="/api/imprint/<%=imprint.id%>/">the title of the imprint?</a>
+                    </li>
+                <% } %>
+                
+                <% if (imprint.language.length < 1) { %> 
+                    <li><span class="glyphicon glyphicon-question-sign" aria-hidden="true"></span>
+                        <a href="#" class="<% if (editable) { %>editable-language<% } %> do-you-know persistant"
+                            data-name="language"
+                            data-type="select2" data-pk="<%=imprint.id%>" data-value=""
+                            data-params="{csrfmiddlewaretoken:'<%=csrf_token%>'}" 
+                        data-url="/api/imprint/<%=imprint.id%>/">the language(s) of the imprint?</a>
+                    </li>
+                <% } %>
+                <% if (!imprint.date_of_publication) { %> 
+                    <li><span class="glyphicon glyphicon-question-sign" aria-hidden="true"></span>
+                    <a href="#" class="<% if (editable) { %>editable<% } %> do-you-know persistant editable-refresh"
+                        data-name="date_string" data-type="text" data-pk="<%=imprint.id%>"
+                        data-value=""
+                        data-params="{csrfmiddlewaretoken:'<%=csrf_token%>',parent_id:<%=imprint.id%>,parent_model:'imprint',attr:'date_of_publication'}"
+                        data-url="/date/add/">the imprint publication date?</a>
+                    </li>
+                <% } %>
+                
+                <% if (!imprint.place) { %> 
+                    <li>
+                        <span class="glyphicon glyphicon-question-sign" aria-hidden="true"></span>
+                        <a href="#" class="<% if (editable) { %>editable-place<% } %> do-you-know persistant"
+                            data-name="place" data-pk="<%=imprint.id%>" data-type="place"
+                            data-params="{csrfmiddlewaretoken:'<%=csrf_token%>',parent_id:<%=imprint.id%>,parent_model:'imprint'}"
+                            data-url="/place/add/">the imprint publication location?</a>
+                    </li>
+                <% } %>
+                
+                <li class="fixed"><span class="glyphicon glyphicon-question-sign" aria-hidden="true"></span>
+                    <a href="#" class="<% if (editable) { %>editable-publisher<% } %> do-you-know persistant" data-name="actor"
+                        data-template="#xeditable-publisher-form"
+                        data-type="actor" data-pk="<%=imprint.id%>" data-value=""
+                        data-params="{csrfmiddlewaretoken:'<%=csrf_token%>',parent_id:<%=imprint.id%>,parent_model:'imprint'}" 
+                        data-url="/actor/add/">people associated with the imprint, e.g. printer, publisher, editor?</a>
+                </li>
+                
+                <% if (!imprint.notes || imprint.notes.length < 1) { %>
+                    <li><span class="glyphicon glyphicon-question-sign" aria-hidden="true"></span>
+                        <a href="#" class="editable do-you-know persistant" data-name="notes"
+                            data-type="textarea" data-pk="<%=imprint.id%>" data-value=""
+                            data-params="{csrfmiddlewaretoken:'<%=csrf_token%>'}"
+                            data-url="/api/imprint/<%=imprint.id%>/">any additional notes about the imprint?</a>
                     </li>
                 <% } %>
             </ul>

--- a/footprints/templates/clientside/footprint_book.html
+++ b/footprints/templates/clientside/footprint_book.html
@@ -1,119 +1,36 @@
 <script type="text/template" id="book-detail-template">
-{% comment %}
 <div class="breadcrumb">THE BOOK</div>
 <dl class="dl-horizontal">
-    <div class="description-list writtenwork-title-container" {% if not work.title %}style="display: none"{% endif %}> 
+    <% if (imprint.work.title.length > 0) { %>
         <dt>Title</dt>
-        <dd><a href="#" class="{% if editable %}editable{% else %}readonly{% endif %}"
+        <dd><a href="#" class="<% if (editable) { %>editable<% } else { %>readonly<% } %>"
                 data-attribute-name="title"  data-name="title"
-                data-type="text" data-pk="{{work.id}}"
-                data-params="{csrfmiddlewaretoken:'{{csrf_token}}'}" 
-                data-url="/api/writtenwork/{{work.id}}/">{{work.title}}</a>
+                data-type="text" data-pk="<%=imprint.work.id%>"
+                data-params="{csrfmiddlewaretoken:'<%=csrf_token%>'}"
+                data-url="/api/writtenwork/<%=imprint.work.id%>/">
+                <%=imprint.work.title%>
+            </a>
         </dd>
-    </div>
-    <div class="description-list writtenwork-author-container">
-        {% for actor in work.actor.all %}
-            <dt>{{actor.role.name}}</dt>
-            <dd class="border-bottom">
-                <span>{{actor.person.name}}{% if actor.alias %} as {{actor.alias}} {% endif %}</span> 
-                <div class="pull-right">
-                    {% if editable %}
-                    <a href="#" class="remove-foreign-key"
-                        data-params="{csrfmiddlewaretoken:'{{csrf_token}}'}" 
-                        data-url="/work/actor/{{footprint.id}}/remove/{{actor.id}}/"
-                        title="remove author">
-                        <span class="glyphicon glyphicon-remove" aria-hidden="true"></span></a>
-                    {% endif %}
-                    &nbsp;
-                    <a href="/person/{{actor.person.id}}/" title="see details" class="foreign-key">
-                        <span class="glyphicon glyphicon-link" aria-hidden="true"></span>
-                    </a>
-                </div>
-            </dd>
-        {% endfor %}
-    </div>
-    <div class="description-list" {% if not work.notes %}style="display: none"{% endif %}>
-        <dt>Notes</dt>
-        <dd class="border-bottom">
-            <a href="#" class="{% if editable %}editable{% else %}readonly{% endif %}"
-                data-attribute-name="notes" data-name="notes"
-                data-type="textarea" data-pk="{{work.id}}"
-                data-params="{csrfmiddlewaretoken:'{{csrf_token}}'}" 
-                data-url="/api/writtenwork/{{work.id}}/">{{work.notes|safe}}</a>
-        </dd>
-    </div>
+    <% } %>
 </dl>
 
-<dl class="dl-horizontal">
-    <div class="description-list" {% if not imprint.title %}style="display: none"{% endif %}>
-        <dt>Imprint Title</dt>
-        <dd class="border-bottom">
-            {{imprint.title}}
-        </dd>
-    </div>
-    <div class="description-list" {% if not imprint.date_of_publication %}style="display: none"{% endif %}>
-        <dt>Publication Date</dt>
-        <dd class="border-bottom">
-            {{imprint.date_of_publication}}
-        </dd>
-    </div>
-    <div class="description-list imprint-actor-container">
-    {% for actor in imprint.actor.all %}
-        <dt>{{actor.role.name}}</dt>
-        <dd class="border-bottom">
-            <span>{{actor.person.name}}{% if actor.alias %} as {{actor.alias}} {% endif %}</span> 
-            <div class="pull-right">
-                {% if editable %}
-                <a href="#" class="remove-foreign-key"
-                    data-params="{csrfmiddlewaretoken:'{{csrf_token}}'}" 
-                    data-url="/imprint/actor/{{imprint.id}}/remove/{{actor.id}}/"
-                    title="remove author">
-                    <span class="glyphicon glyphicon-remove" aria-hidden="true"></span></a>
-                {% endif %}
-                &nbsp;
-                <a href="/person/{{actor.person.id}}/" title="see details" class="foreign-key">
-                    <span class="glyphicon glyphicon-link" aria-hidden="true"></span>
-                </a>
-            </div>
-        </dd>
-    {% endfor %}
-    </div>
-</dl>
 
-{% if editable %}
+<% if (editable) { %>
     <dl class="dl-horizontal">
         <dt>Do you know...</dt>
         <dd>  
             <ul class="additional-questions">
-                {% if not work.title %}
-                    <li class="writtenwork-title-container">
+                <% if (imprint.work.title.length < 1) { %>
+                    <li>
                         <span class="glyphicon glyphicon-question-sign" aria-hidden="true"></span>
-                        <a href="#" class="{% if editable %}editable{% endif %} do-you-know persistant"
-                            data-name="title" data-type="text" data-pk="{{work.id}}" data-value=""
-                            data-params="{csrfmiddlewaretoken:'{{csrf_token}}'}"
-                            data-url="/api/writtenwork/{{work.id}}/">the title of the written work?</a>
+                        <a href="#" class="<% if (editable) { %>editable<% } %> do-you-know persistant"
+                            data-name="title" data-type="text" data-pk="<%=imprint.work.id%>" data-value=""
+                            data-params="{csrfmiddlewaretoken:'<%=csrf_token%>'}"
+                            data-url="/api/writtenwork/<%=imprint.work.id%>/">the title of the written work?</a>
                     </li>
-                {% endif %}
-                <li class="fixed"><span class="glyphicon glyphicon-question-sign" aria-hidden="true"></span>
-                    <a href="#" class="{% if editable %}editable-author{% endif %} do-you-know persistant" data-name="actor"
-                        data-template="#xeditable-author-form" 
-                        data-type="actor" data-pk="{{work.id}}" data-value=""
-                        data-params="{csrfmiddlewaretoken:'{{csrf_token}}'}" 
-                        data-url="/work/actor/{{footprint.id}}/add/">the author(s) of the written work?</a>
-                </li>
-                
-                {% if not work.notes %}
-                    <li><span class="glyphicon glyphicon-question-sign" aria-hidden="true"></span>
-                        <a href="#" class="editable do-you-know persistant" data-name="notes"
-                            data-type="textarea" data-pk="{{work.id}}" data-value=""
-                            data-params="{csrfmiddlewaretoken:'{{csrf_token}}'}"
-                            data-url="/api/writtenwork/{{work.id}}/">any additional notes about the written work?</a>
-                    </li>
-                {% endif %}
-
+                <% } %>
             </ul>
        </dd>
     </dl>
-{% endif %}
-{% endcomment %}
+<% } %>
 </script>

--- a/footprints/templates/clientside/footprint_book.html
+++ b/footprints/templates/clientside/footprint_book.html
@@ -1,0 +1,119 @@
+<script type="text/template" id="book-detail-template">
+{% comment %}
+<div class="breadcrumb">THE BOOK</div>
+<dl class="dl-horizontal">
+    <div class="description-list writtenwork-title-container" {% if not work.title %}style="display: none"{% endif %}> 
+        <dt>Title</dt>
+        <dd><a href="#" class="{% if editable %}editable{% else %}readonly{% endif %}"
+                data-attribute-name="title"  data-name="title"
+                data-type="text" data-pk="{{work.id}}"
+                data-params="{csrfmiddlewaretoken:'{{csrf_token}}'}" 
+                data-url="/api/writtenwork/{{work.id}}/">{{work.title}}</a>
+        </dd>
+    </div>
+    <div class="description-list writtenwork-author-container">
+        {% for actor in work.actor.all %}
+            <dt>{{actor.role.name}}</dt>
+            <dd class="border-bottom">
+                <span>{{actor.person.name}}{% if actor.alias %} as {{actor.alias}} {% endif %}</span> 
+                <div class="pull-right">
+                    {% if editable %}
+                    <a href="#" class="remove-foreign-key"
+                        data-params="{csrfmiddlewaretoken:'{{csrf_token}}'}" 
+                        data-url="/work/actor/{{footprint.id}}/remove/{{actor.id}}/"
+                        title="remove author">
+                        <span class="glyphicon glyphicon-remove" aria-hidden="true"></span></a>
+                    {% endif %}
+                    &nbsp;
+                    <a href="/person/{{actor.person.id}}/" title="see details" class="foreign-key">
+                        <span class="glyphicon glyphicon-link" aria-hidden="true"></span>
+                    </a>
+                </div>
+            </dd>
+        {% endfor %}
+    </div>
+    <div class="description-list" {% if not work.notes %}style="display: none"{% endif %}>
+        <dt>Notes</dt>
+        <dd class="border-bottom">
+            <a href="#" class="{% if editable %}editable{% else %}readonly{% endif %}"
+                data-attribute-name="notes" data-name="notes"
+                data-type="textarea" data-pk="{{work.id}}"
+                data-params="{csrfmiddlewaretoken:'{{csrf_token}}'}" 
+                data-url="/api/writtenwork/{{work.id}}/">{{work.notes|safe}}</a>
+        </dd>
+    </div>
+</dl>
+
+<dl class="dl-horizontal">
+    <div class="description-list" {% if not imprint.title %}style="display: none"{% endif %}>
+        <dt>Imprint Title</dt>
+        <dd class="border-bottom">
+            {{imprint.title}}
+        </dd>
+    </div>
+    <div class="description-list" {% if not imprint.date_of_publication %}style="display: none"{% endif %}>
+        <dt>Publication Date</dt>
+        <dd class="border-bottom">
+            {{imprint.date_of_publication}}
+        </dd>
+    </div>
+    <div class="description-list imprint-actor-container">
+    {% for actor in imprint.actor.all %}
+        <dt>{{actor.role.name}}</dt>
+        <dd class="border-bottom">
+            <span>{{actor.person.name}}{% if actor.alias %} as {{actor.alias}} {% endif %}</span> 
+            <div class="pull-right">
+                {% if editable %}
+                <a href="#" class="remove-foreign-key"
+                    data-params="{csrfmiddlewaretoken:'{{csrf_token}}'}" 
+                    data-url="/imprint/actor/{{imprint.id}}/remove/{{actor.id}}/"
+                    title="remove author">
+                    <span class="glyphicon glyphicon-remove" aria-hidden="true"></span></a>
+                {% endif %}
+                &nbsp;
+                <a href="/person/{{actor.person.id}}/" title="see details" class="foreign-key">
+                    <span class="glyphicon glyphicon-link" aria-hidden="true"></span>
+                </a>
+            </div>
+        </dd>
+    {% endfor %}
+    </div>
+</dl>
+
+{% if editable %}
+    <dl class="dl-horizontal">
+        <dt>Do you know...</dt>
+        <dd>  
+            <ul class="additional-questions">
+                {% if not work.title %}
+                    <li class="writtenwork-title-container">
+                        <span class="glyphicon glyphicon-question-sign" aria-hidden="true"></span>
+                        <a href="#" class="{% if editable %}editable{% endif %} do-you-know persistant"
+                            data-name="title" data-type="text" data-pk="{{work.id}}" data-value=""
+                            data-params="{csrfmiddlewaretoken:'{{csrf_token}}'}"
+                            data-url="/api/writtenwork/{{work.id}}/">the title of the written work?</a>
+                    </li>
+                {% endif %}
+                <li class="fixed"><span class="glyphicon glyphicon-question-sign" aria-hidden="true"></span>
+                    <a href="#" class="{% if editable %}editable-author{% endif %} do-you-know persistant" data-name="actor"
+                        data-template="#xeditable-author-form" 
+                        data-type="actor" data-pk="{{work.id}}" data-value=""
+                        data-params="{csrfmiddlewaretoken:'{{csrf_token}}'}" 
+                        data-url="/work/actor/{{footprint.id}}/add/">the author(s) of the written work?</a>
+                </li>
+                
+                {% if not work.notes %}
+                    <li><span class="glyphicon glyphicon-question-sign" aria-hidden="true"></span>
+                        <a href="#" class="editable do-you-know persistant" data-name="notes"
+                            data-type="textarea" data-pk="{{work.id}}" data-value=""
+                            data-params="{csrfmiddlewaretoken:'{{csrf_token}}'}"
+                            data-url="/api/writtenwork/{{work.id}}/">any additional notes about the written work?</a>
+                    </li>
+                {% endif %}
+
+            </ul>
+       </dd>
+    </dl>
+{% endif %}
+{% endcomment %}
+</script>

--- a/footprints/templates/clientside/footprint_progress.html
+++ b/footprints/templates/clientside/footprint_progress.html
@@ -1,7 +1,7 @@
 <script type="text/template" id="progress-sidebar-template">
     <ul class="list-group record-checklist">
         <li class="list-group-item">
-            <h4>Record Progress</h4>
+            <h4>Record Checklist</h4>
             <div>
                 <div class="progress pull-left">
                     <div class="progress-bar" role="progressbar"
@@ -18,17 +18,32 @@
             <small>type, location</small>
         </li>
         <li class="list-group-item">
-            <span class="glyphicon glyphicon-unchecked" aria-hidden="true"></span>&nbsp;&nbsp;The Book Title
+            <% if (book.imprint.work && book.imprint.work.title && book.imprint.work.title.length > 0) {%>
+                <span class="glyphicon glyphicon-check" aria-hidden="true"></span>
+            <% } else { %>
+                <span class="glyphicon glyphicon-unchecked" aria-hidden="true"></span>
+            <% } %>
+            
+            &nbsp;&nbsp;The Book Title
         </li>
         <li class="list-group-item">
-            <span class="glyphicon glyphicon-unchecked" aria-hidden="true"></span>
+            <% if (book.imprint.work && book.imprint.work.actor.length > 0) {%>
+                <span class="glyphicon glyphicon-check" aria-hidden="true"></span>
+            <% } else { %>
+                <span class="glyphicon glyphicon-unchecked" aria-hidden="true"></span>
+            <% } %>
             &nbsp;&nbsp;The Book Author(s)
         </li>
-        <li class="list-group-item" data-related-fields="">
-            <span class="glyphicon glyphicon-unchecked" aria-hidden="true"></span>&nbsp;&nbsp;Imprint Details<br />
+        <li class="list-group-item">
+            <% if (book.imprint.work && book.imprint.actor.length > 0 && book.imprint.date_of_publication && book.imprint.place) { %>
+                <span class="glyphicon glyphicon-check" aria-hidden="true"></span>
+            <% } else { %>
+                <span class="glyphicon glyphicon-unchecked" aria-hidden="true"></span>
+            <% } %>
+            </span>&nbsp;&nbsp;Imprint Details<br />
             <small>publisher, date, location</small>
         </li>
-        <li class="list-group-item <% if (footprint.associated_date && footprint.place) { %>list-item-complete<% } %>">
+        <li class="list-group-item">
             <% if (footprint.associated_date && footprint.place) { %>
                 <span class="glyphicon glyphicon-check" aria-hidden="true"></span>
             <% } else { %>

--- a/footprints/templates/clientside/footprint_progress.html
+++ b/footprints/templates/clientside/footprint_progress.html
@@ -1,67 +1,49 @@
 <script type="text/template" id="progress-sidebar-template">
-{% comment %}
-                {% with complete=footprint.percent_complete %}
-                    <ul class="list-group record-checklist">
-                        <li class="list-group-item">
-                            <h4>Record Progress</h4>
-                            <div>
-                                <div class="progress pull-left">
-                                    <div class="progress-bar" role="progressbar"
-                                        aria-valuenow="{{complete}}" aria-valuemin="0"
-                                        aria-valuemax="100" style="width: {{complete}}%;">
-                                    </div>
-                                </div>
-                                <div class="progress-report pull-right">{{complete}}% complete</div>
-                            </div>
-                            <div class="clearfix"></div>
-                        </li>
-                        <li class="list-group-item list-item-complete" data-related-fields=".evidence-type-container, .evidence-location-container">
-                            <span class="glyphicon glyphicon-check" aria-hidden="true"></span>&nbsp;&nbsp;Footprint Evidence<br />
-                            <small>type, location</small>
-                        </li>
-                        <li class="list-group-item {% if work.title %}list-item-complete"{% endif %}
-                            data-related-fields=".writtenwork-title-container">
-                            {% if work.title %}
-                                <span class="glyphicon glyphicon-check" aria-hidden="true"></span>&nbsp;&nbsp;The Book Title
-                            {% else %}
-                                <span class="glyphicon glyphicon-unchecked" aria-hidden="true"></span>&nbsp;&nbsp;The Book Title
-                            {% endif %}
-                        </li>
-                            <li class="list-group-item {% if work.actor|length > 0 %}list-item-complete{% endif %}" data-related-fields=".writtenwork-author-container">
-                            {% if work.actor|length > 0 %}
-                                <span class="glyphicon glyphicon-check" aria-hidden="true"></span>
-                            {% else %}
-                                <span class="glyphicon glyphicon-unchecked" aria-hidden="true"></span>
-                            {% endif %}
-                            &nbsp;&nbsp;The Book Author(s)
-                        </li>
-                        <li class="list-group-item" data-related-fields="">
-                            <span class="glyphicon glyphicon-unchecked" aria-hidden="true"></span>&nbsp;&nbsp;Imprint Details<br />
-                            <small>publisher, date, location</small>
-                        </li>
-                        <li class="list-group-item {% if footprint.associated_date and footprint.place %}list-item-complete{% endif%}" 
-                            data-related-fields=".footprint-date-container, .footprint-place-container">
-                            {% if footprint.associated_date and footprint.place %}
-                                <span class="glyphicon glyphicon-check" aria-hidden="true"></span>
-                            {% else %}
-                                <span class="glyphicon glyphicon-unchecked" aria-hidden="true"></span>
-                            {% endif %}
-                            Footprint Details<br />
-                            <small>date, location</small>
-                        </li>
-                    </ul>
-                {% endwith %}
-                <div class="clearfix"></div>
-
-                {% if editable %}
-                <div class="sidebar-box">
-                    <h4>Can you connect this record?</h4>
-                    <p>Further describe your footprint by connecting similar records.</p>
-                    {% for record in records %}
-                        {{record}}
-                    {% endfor %}
+    <ul class="list-group record-checklist">
+        <li class="list-group-item">
+            <h4>Record Progress</h4>
+            <div>
+                <div class="progress pull-left">
+                    <div class="progress-bar" role="progressbar"
+                        aria-valuenow="<%=footprint.percent_complete%>" aria-valuemin="0"
+                        aria-valuemax="100" style="width: <%=footprint.percent_complete%>%;">
+                    </div>
                 </div>
-                {% endif %}
+                <div class="progress-report pull-right"><%=footprint.percent_complete%>% complete</div>
             </div>
-{% endcomment %}
+            <div class="clearfix"></div>
+        </li>
+        <li class="list-group-item list-item-complete">
+            <span class="glyphicon glyphicon-check" aria-hidden="true"></span>&nbsp;&nbsp;Footprint Evidence<br />
+            <small>type, location</small>
+        </li>
+        <li class="list-group-item">
+            <span class="glyphicon glyphicon-unchecked" aria-hidden="true"></span>&nbsp;&nbsp;The Book Title
+        </li>
+        <li class="list-group-item">
+            <span class="glyphicon glyphicon-unchecked" aria-hidden="true"></span>
+            &nbsp;&nbsp;The Book Author(s)
+        </li>
+        <li class="list-group-item" data-related-fields="">
+            <span class="glyphicon glyphicon-unchecked" aria-hidden="true"></span>&nbsp;&nbsp;Imprint Details<br />
+            <small>publisher, date, location</small>
+        </li>
+        <li class="list-group-item <% if (footprint.associated_date && footprint.place) { %>list-item-complete<% } %>">
+            <% if (footprint.associated_date && footprint.place) { %>
+                <span class="glyphicon glyphicon-check" aria-hidden="true"></span>
+            <% } else { %>
+                <span class="glyphicon glyphicon-unchecked" aria-hidden="true"></span>
+            <% } %>
+            Footprint Details<br />
+            <small>date, location</small>
+        </li>
+    </ul>
+    <div class="clearfix"></div>
+
+    <% if (editable) { %>
+        <div class="sidebar-box">
+            <h4>Can you connect this record?</h4>
+            <p>Further describe your footprint by connecting similar records.</p>
+        </div>
+    <% } %>
 </script>

--- a/footprints/templates/clientside/footprint_progress.html
+++ b/footprints/templates/clientside/footprint_progress.html
@@ -1,0 +1,67 @@
+<script type="text/template" id="progress-sidebar-template">
+{% comment %}
+                {% with complete=footprint.percent_complete %}
+                    <ul class="list-group record-checklist">
+                        <li class="list-group-item">
+                            <h4>Record Progress</h4>
+                            <div>
+                                <div class="progress pull-left">
+                                    <div class="progress-bar" role="progressbar"
+                                        aria-valuenow="{{complete}}" aria-valuemin="0"
+                                        aria-valuemax="100" style="width: {{complete}}%;">
+                                    </div>
+                                </div>
+                                <div class="progress-report pull-right">{{complete}}% complete</div>
+                            </div>
+                            <div class="clearfix"></div>
+                        </li>
+                        <li class="list-group-item list-item-complete" data-related-fields=".evidence-type-container, .evidence-location-container">
+                            <span class="glyphicon glyphicon-check" aria-hidden="true"></span>&nbsp;&nbsp;Footprint Evidence<br />
+                            <small>type, location</small>
+                        </li>
+                        <li class="list-group-item {% if work.title %}list-item-complete"{% endif %}
+                            data-related-fields=".writtenwork-title-container">
+                            {% if work.title %}
+                                <span class="glyphicon glyphicon-check" aria-hidden="true"></span>&nbsp;&nbsp;The Book Title
+                            {% else %}
+                                <span class="glyphicon glyphicon-unchecked" aria-hidden="true"></span>&nbsp;&nbsp;The Book Title
+                            {% endif %}
+                        </li>
+                            <li class="list-group-item {% if work.actor|length > 0 %}list-item-complete{% endif %}" data-related-fields=".writtenwork-author-container">
+                            {% if work.actor|length > 0 %}
+                                <span class="glyphicon glyphicon-check" aria-hidden="true"></span>
+                            {% else %}
+                                <span class="glyphicon glyphicon-unchecked" aria-hidden="true"></span>
+                            {% endif %}
+                            &nbsp;&nbsp;The Book Author(s)
+                        </li>
+                        <li class="list-group-item" data-related-fields="">
+                            <span class="glyphicon glyphicon-unchecked" aria-hidden="true"></span>&nbsp;&nbsp;Imprint Details<br />
+                            <small>publisher, date, location</small>
+                        </li>
+                        <li class="list-group-item {% if footprint.associated_date and footprint.place %}list-item-complete{% endif%}" 
+                            data-related-fields=".footprint-date-container, .footprint-place-container">
+                            {% if footprint.associated_date and footprint.place %}
+                                <span class="glyphicon glyphicon-check" aria-hidden="true"></span>
+                            {% else %}
+                                <span class="glyphicon glyphicon-unchecked" aria-hidden="true"></span>
+                            {% endif %}
+                            Footprint Details<br />
+                            <small>date, location</small>
+                        </li>
+                    </ul>
+                {% endwith %}
+                <div class="clearfix"></div>
+
+                {% if editable %}
+                <div class="sidebar-box">
+                    <h4>Can you connect this record?</h4>
+                    <p>Further describe your footprint by connecting similar records.</p>
+                    {% for record in records %}
+                        {{record}}
+                    {% endfor %}
+                </div>
+                {% endif %}
+            </div>
+{% endcomment %}
+</script>

--- a/footprints/templates/main/footprint_detail.html
+++ b/footprints/templates/main/footprint_detail.html
@@ -13,6 +13,7 @@
     
     {% include "xeditable/actor.html" %}
     {% include "xeditable/author.html" %}
+    {% include "xeditable/publisher.html" %}
     {% include "xeditable/place.html" %}
     {% include "clientside/footprint.html" %}
     {% include "clientside/footprint_book.html" %}

--- a/footprints/templates/main/footprint_detail.html
+++ b/footprints/templates/main/footprint_detail.html
@@ -39,6 +39,7 @@
             var editView = new FootprintView({
                 el: jQuery('div.object-detail'),
                 footprint: {'id': '{{footprint.id}}'},
+                book_copy: {'id': '{{footprint.book_copy.id}}'},
                 detailTemplate: jQuery('#footprint-detail-template'),
                 bookTemplate: jQuery('#book-detail-template'),
                 progressTemplate: jQuery('#progress-sidebar-template'),

--- a/footprints/templates/main/footprint_detail.html
+++ b/footprints/templates/main/footprint_detail.html
@@ -10,147 +10,19 @@
 
 {% block extrahead %}
     <link href="{{STATIC_URL}}select2-3.5.2/select2.css" rel="stylesheet" />
-
-    <script type="text/template" id="xeditable-actor-form">
-        <div class="editable-actor">
-            <div class="form-group">
-                <label>Person's Name</label><br />
-                <input type="text" class="form-control" name="person-autocomplete" placeholder="Type in a person's name"></input>
-            </div>
-                    
-            <div class="form-group">
-                <label>Pseudonym or Alias (if applicable)</label><br />
-                <input type="text" class="form-control" name="actor-name" placeholder="Specify the person's alias"></select>
-            </div>
-
-            <div class="form-group">
-                <label>Role</label><br />
-                <select class="form-control" name="role" placeholder="Type in a role name">
-                    {% for role in roles.for_footprint %}
-                        <option value="{{role.id}}">{{role.name}}</option>
-                    {% endfor %}
-                </select>
-            </div>
-        </div>
-    </script>
-
-    <script type="text/template" id="xeditable-author-form">
-        <div class="editable-author">
-            <div class="form-group">
-                <label>Author's Name</label><br />
-                <input type="text" class="form-control" name="person-autocomplete" placeholder="Type in a person's name"></input>
-                </div>
-                
-            <div class="form-group">
-                <label>Pseudonym or Alias (if applicable)</label><br />
-                <input type="text" class="form-control" name="actor-name" placeholder="Specify the person's alias"></select>
-            </div>
-
-            <div class="form-group" style="display: none">
-                <label>Role</label><br />
-                <select class="form-control" name="role" placeholder="Type in a role name" disabled="disabled">
-                    {% with author=roles.get_author_role %}
-                        <option value="{{author.id}}">{{author.name}}</option>
-                    {% endwith %}
-                </select>
-            </div>
-        </div>
-    </script>
-
-    <script type="text/template" id="xeditable-imprint-actor-form">
-        <div class="editable-actor">
-            <div class="form-group">
-                <label>Person's Name</label><br />
-                <input type="text" class="form-control" name="person-autocomplete" placeholder="Type in a person's name"></input>
-            </div>
-            
-            <div class="form-group">
-                <label>Pseudonym or Alias (if applicable)</label><br />
-                <input type="text" class="form-control" name="actor-name" placeholder="Specify the person's alias"></select>
-            </div>
-
-            <div class="form-group" style="display: none">
-                <label>Role</label><br />
-                <select class="form-control" name="role" placeholder="Type in a role name" disabled="disabled">
-                    {% with author=roles.for_imprint %}
-                        <option value="{{author.id}}">{{author.name}}</option>
-                    {% endwith %}
-                </select>
-            </div>
-        </div>
-    </script>
-
-    <script type="text-template" id="actor-display-template">
-        <dt><%=actor.role.name%></dt>
-        <dd class="border-bottom">
-            <span><%=actor.person.name %><% if (actor.alias.length > 0) { %> as <%=actor.alias%> <% } %></span> 
-            <div class="pull-right">
-                <a href="#" class="remove-foreign-key"
-                    data-params="{csrfmiddlewaretoken:'{{csrf_token}}'}"
-                    data-url="/<%=object.type%>/actor/<%=object.id%>/remove/<%=actor.id%>/"
-                    title="remove actor">
-                    <span class="glyphicon glyphicon-remove" aria-hidden="true"></span></a>
-                &nbsp;
-                <a href="/person/<%=actor.person.id%>/" title="see details" class="foreign-key">
-                    <span class="glyphicon glyphicon-link" aria-hidden="true"></span>
-                </a>
-            </div>
-        </dd>
-    </script>
-
-    <script type="text/template" id="xeditable-place-form">
-        <div class="editable-place">
-            <div class="form-group">
-                <label>Pinpoint the location on a map</label> 
-                <div class="help-block">
-                    Search by address or click the map to drop a marker.<br />
-                    City and country values will autopopulate based on the map location.<br />
-                    These modern names can be updated if not historically accurate. 
-                </div>
-                <input class="form-control" placeholder="Search for an address..." name="address" type="text"></div>
-                <div class="map-container"></div>
-            </div>
-            <div class="row" style="width: 120%;">
-                <div class="col-md-6">
-                    <div class="form-group">
-                        <label>City</label>
-                        <input class="form-control" placeholder="City" maxlength="256" name="city" type="text">
-                        </div>
-                </div>
-                <div class="col-md-6">
-                    <div class="form-group">
-                        <label>Country</label>
-                        <input class="form-control" placeholder="Country" maxlength="256" name="country" type="text">
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </script>
     
-    <script type="text/template" id="place-display-template">
-        <dt>Footprint Place</dt>
-        <dd class="border-bottom footprint-place">
-            <span><%= place.description %></span>
-            <div class="pull-right">
-                <a href="#" class="remove-foreign-key"
-                    data-params="{csrfmiddlewaretoken:'{{csrf_token}}'}" 
-                    data-url="/footprint/place/<%=footprint_id%>/remove/<%= place.id%>/"
-                    title="remove place">
-                    <span class="glyphicon glyphicon-remove" aria-hidden="true"></span></a>
-                &nbsp;
-                <a href="/place/<%=place.id%>/" title="see details" class="foreign-key">
-                    <span class="glyphicon glyphicon-link" aria-hidden="true"></span>
-                </a>
-            </div>
-        </dd>
-    </script>
+    {% include "xeditable/actor.html" %}
+    {% include "xeditable/author.html" %}
+    {% include "xeditable/place.html" %}
+    {% include "clientside/footprint.html" %}
+    {% include "clientside/footprint_book.html" %}
+    {% include "clientside/footprint_progress.html" %}
 {% endblock %}
 
 {% block js %}
+    <script type="text/javascript" src="//maps.google.com/maps/api/js?libraries=places&sensor=false"></script>
     <script src="{{STATIC_URL}}js/underscore-min.js"></script>
     <script src="{{STATIC_URL}}js/backbone-min.js"></script>
-    <script type="text/javascript" src="//maps.google.com/maps/api/js?libraries=places&sensor=false"></script>
     <script src="{{STATIC_URL}}tinymce/tinymce.min.js"></script>
 
     {% compress js %}
@@ -164,461 +36,55 @@
 
     <script type="text/javascript">
         jQuery(document).ready(function() {
-            var editView = new EditFootprintView({
-                el: jQuery("div.object-detail.footprint"),
-                languages: [{% for language in languages %}
-                            {value: '{{language.id}}', text: "{{language.name}}"}{% if not forloop.last %},{% endif %}
-                            {% endfor %}],
-                mediums:  [{% for medium in footprint.MEDIUM_CHOICES %}
-                           {value: '{{medium}}', text: "{{medium}}"}{% if not forloop.last %},{% endif %}
-                           {% endfor %}],
+            var editView = new FootprintView({
+                el: jQuery('div.object-detail'),
+                footprint: {'id': '{{footprint.id}}'},
+                detailTemplate: jQuery('#footprint-detail-template'),
+                bookTemplate: jQuery('#book-detail-template'),
+                progressTemplate: jQuery('#progress-sidebar-template'),
+                baseContext: {
+                    all_languages: [{% for language in languages %}
+                                    {value: '{{language.id}}', text: "{{language.name}}"}{% if not forloop.last %},{% endif %}
+                                    {% endfor %}],
+                    all_mediums:  [{% for medium in footprint.MEDIUM_CHOICES %}
+                                   {value: '{{medium}}', text: "{{medium}}"}{% if not forloop.last %},{% endif %}
+                                   {% endfor %}],
+                    editable: {% if editable %}true{% else %}false{% endif %},
+                    csrf_token: '{{csrf_token}}',
+                    static_url: '{{STATIC_URL}}'
+                }
             });
         });
     </script>
-
 {% endblock %}
 
 {% block content %}
-    {% with footprint=object book=object.book_copy imprint=object.book_copy.imprint work=object.book_copy.imprint.work %}
-    <div class="object-detail footprint">
+    <div class="object-detail">
         {% csrf_token %}
         <div class="row">
             <div class="col-md-8">
-                <h1>
-                    <img class="pull-left" src="{{STATIC_URL}}img/footprint.png" />
-                    <span class="pull-left object-title" data-name='display-title'>{{footprint.display_title}}</span>
-                    <div class="clearfix"></div>
-                </h1>
-
-                <div class="breadcrumb">A FOOTPRINT</div>
-                {% for media in footprint.digital_object.all %}
-                    <img src="{{media.file.url}}"></img>
-                {% endfor %}
-                {% if footprint.narrative %}
-                    <blockquote class="blockquote">
-                    {{footprint.narrative}}
-                    </blockquote>
-                {% endif %}
-                <div class="evidence-container">
-                    <dl class="dl-horizontal">
-                        <div class="description-list footprint-date-container"
-                            {% if not footprint.associated_date %}style="display: none"{% endif %}>
-                            <dt>Footprint Date</dt>
-                            <dd class="border-bottom">
-                                <a href="#" class="{% if editable %}editable editable-date{% else %}readonly{% endif %}"
-                                    data-attribute-name="associated_date" data-name="edtf_format"
-                                    data-type="text" data-pk="{{footprint.associated_date.id}}"
-                                    data-params="{csrfmiddlewaretoken:'{{csrf_token}}'}"
-                                    {% if footprint.associated_date.id %}
-                                        data-url="/api/edtf/{{footprint.associated_date.id}}/"
-                                    {% else %}
-                                        data-url="/api/edtf/"
-                                    {% endif %}>{{footprint.associated_date}}</a>
-                            </dd>
-                        </div>
-                        <div class="footprint-place footprint-place-container" {% if not footprint.place %}style="display: none"{% endif %}>
-                            <dt>Footprint Place</dt>
-                            <dd class="border-bottom footprint-place">
-                                <span>{{footprint.place}}</span>
-                                <div class="pull-right">
-                                    {% if editable %}
-                                        <a href="#" class="remove-foreign-key"
-                                            data-params="{csrfmiddlewaretoken:'{{csrf_token}}'}" 
-                                            data-url="/footprint/place/{{footprint.id}}/remove/{{footprint.place.id}}/"
-                                            title="remove place">
-                                            <span class="glyphicon glyphicon-remove" aria-hidden="true"></span>
-                                        </a>
-                                    {% endif %}
-                                    &nbsp;
-                                    <a href="/place/{{footprint.place.id}}/" title="see details" class="foreign-key">
-                                        <span class="glyphicon glyphicon-link" aria-hidden="true"></span>
-                                    </a>
-                                </div>
-                                <div class="clearfix"></div>
-                                <div class="footprint-map"
-                                    data-latitude="{{footprint.place.position.latitude}}"
-                                    data-longitude="{{footprint.place.position.longitude}}"
-                                    data-title="{{footprint.place}}">
-                                </div>
-                            </dd>
-                        </div>
-                        <div class="description-list" {% if footprint.language.count < 1 %}style="display: none"{% endif %}>
-                            <dt>Footprint Language</dt>
-                            <dd class="border-bottom">
-                                <a href="#" class="{% if editable %}editable-language{% else %}readonly{% endif %}"
-                                    data-attribute-name="language" data-name="language"
-                                    data-type="select2" data-pk="{{footprint.id}}"
-                                    data-value="[{% for language in footprint.language.all %}{{language.id}}{% if not forloop.last %},{% endif %}{% endfor %}]"
-                                    data-params="{csrfmiddlewaretoken:'{{csrf_token}}'}"
-                                    data-url="/api/footprint/{{footprint.id}}/">
-                                    {% for language in footprint.language.all %}
-                                        {{language.name}}{% if not forloop.last %}, {% endif %}
-                                    {% endfor %}
-                                </a>
-                            </dd>
-                        </div>
-                        {% ifnotequal footprint.title footprint.display_title %}
-                        <div class="description-list" {% if not footprint.title %}style="display: none"{% endif %}>
-                            <dt title="the written work's title exactly as it appears in the of evidence.">Footprint Title Display<br /></dt>
-                            <dd class="border-bottom">
-                                <a href="#" class="{% if editable %}editable{% else %}readonly{% endif %}"
-                                    data-attribute-name="title" data-name="title"
-                                    data-type="text" data-pk="{{footprint.id}}"
-                                    data-params="{csrfmiddlewaretoken:'{{csrf_token}}'}" 
-                                    data-url="/api/footprint/{{footprint.id}}/">{{footprint.title}}</a>
-                            </dd>
-                        </div>
-                        {% endifnotequal %}
-                        
-                        <div class="actor-list">
-                            {% for actor in footprint.actor.all %}
-                                <dt>{{actor.role.name}}</dt>
-                                <dd class="border-bottom">
-                                    <span>{{actor.person.name}}{% if actor.alias %} as {{actor.alias}} {% endif %}</span> 
-                                    <div class="pull-right">
-                                        {% if editable %}
-                                        <a href="#" class="remove-foreign-key"
-                                            data-params="{csrfmiddlewaretoken:'{{csrf_token}}'}" 
-                                            data-url="/footprint/actor/{{footprint.id}}/remove/{{actor.id}}/"
-                                            title="remove actor">
-                                            <span class="glyphicon glyphicon-remove" aria-hidden="true"></span></a>
-                                        {% endif %}
-                                        &nbsp;
-                                        <a href="/person/{{actor.person.id}}/" title="see details" class="foreign-key">
-                                            <span class="glyphicon glyphicon-link" aria-hidden="true"></span>
-                                        </a>
-                                    </div>
-                                </dd>
-                            {% endfor %}
-                       </div>
-                    </dl>
-                    <dl class="dl-horizontal">
-                        <div class="evidence-type-container">
-                        <dt>Evidence Type</dt>
-                        <dd class="border-bottom">
-                            <a href="#" class="{% if editable %}editable-medium{% else %}readonly{% endif %}"
-                                data-attribute-name="medium" data-name="medium"
-                                data-type="select2" data-pk="{{footprint.id}}"
-                                data-value="{{footprint.medium}}"
-                                data-params="{csrfmiddlewaretoken:'{{csrf_token}}'}"
-                                data-url="/api/footprint/{{footprint.id}}/">{{footprint.medium}}
-                            </a>
-                        </dd>
-                        </div>
-                        <div class="description-list"
-                            {% if footprint.medium_description == None or footprint.medium_description == ''%}style="display: none"{% endif %}>
-                            <dt>Evidence Description</dt>
-                            <dd class="border-bottom">
-                                <a href="#" class="{% if editable %}editable{% else %}readonly{% endif %}"
-                                    data-attribute-name="medium_description" data-name="medium_description"
-                                    data-type="text" data-pk="{{footprint.id}}"
-                                    data-params="{csrfmiddlewaretoken:'{{csrf_token}}'}" 
-                                    data-url="/api/footprint/{{footprint.id}}/">{{footprint.medium_description}}</a>
-                            </dd>
-                        </div>
-                        <div class="evidence-location-container">
-                            <dt>Evidence Location</dt>
-                            <dd class="border-bottom">
-                                <a href="#" class="{% if editable %}editable{% else %}readonly{% endif %}"
-                                    data-attribute-name="provenance" data-name="provenance"
-                                    data-type="text" data-pk="{{footprint.id}}"
-                                    data-params="{csrfmiddlewaretoken:'{{csrf_token}}'}" 
-                                    data-url="/api/footprint/{{footprint.id}}/">{{footprint.provenance}}</a>
-                            </dd>
-                        </div>
-                        <div class="description-list" {% if footprint.call_number == None or footprint.call_number == '' %}style="display: none"{% endif %}>
-                            <dt>Evidence Call Number</dt>
-                            <dd class="border-bottom">
-                                <a href="#" class="{% if editable %}editable{% else %}readonly{% endif %}"
-                                    data-attribute-name="call_number"  data-name="call_number"
-                                    data-type="text" data-pk="{{footprint.id}}"
-                                    data-params="{csrfmiddlewaretoken:'{{csrf_token}}'}" 
-                                    data-url="/api/footprint/{{footprint.id}}/">{{footprint.call_number}}</a>
-                            </dd>
-                        </div>                        
-                        <div class="description-list" {% if not footprint.notes %}style="display: none"{% endif %}>
-                            <dt>Notes</dt>
-                            <dd class="border-bottom">
-                                <a href="#" class="{% if editable %}editable{% else %}readonly{% endif %}"
-                                    data-attribute-name="notes" data-name="notes"
-                                    data-type="textarea" data-pk="{{footprint.id}}"
-                                    data-params="{csrfmiddlewaretoken:'{{csrf_token}}'}" 
-                                    data-url="/api/footprint/{{footprint.id}}/">{{footprint.notes|safe}}</a>
-                            </dd>
-                        </div>
-                    </dl>
-                    {% if editable %}
-                    <dl class="dl-horizontal">
-                        <dt>Do you know...</dt>
-                        <dd>  
-                            <ul class="additional-questions">
-                                {% if not footprint.place %}
-                                    <li class="footprint-place-container">
-                                        <span class="glyphicon glyphicon-question-sign" aria-hidden="true"></span>
-                                        <a href="#" class="{% if editable %}editable-place{% endif %} do-you-know persistant" data-name="place"
-                                            data-type="place" data-pk="{{footprint.id}}" data-value=""
-                                            data-params="{csrfmiddlewaretoken:'{{csrf_token}}'}" 
-                                            data-url="/footprint/place/{{footprint.id}}/add/">the place where the footprint occurred?</a>
-                                    </li>
-                                {% endif %}
-                                {% if not footprint.associated_date %}
-                                    <li class="footprint-date-container"><span class="glyphicon glyphicon-question-sign" aria-hidden="true"></span>
-                                    <a href="#" class="{% if editable %}editable editable-date{% endif %} do-you-know persistant"
-                                        data-name="associated_date"
-                                        data-type="text" data-pk="{{footprint.id}}"
-                                        data-params="{csrfmiddlewaretoken:'{{csrf_token}}'}" data-value=""
-                                        data-url="/footprint/date/{{footprint.id}}/">the date when the footprint occurred?</a>
-                                    </li>
-                                {% endif %}
-                                {% if footprint.language.count < 1 %}
-                                    <li><span class="glyphicon glyphicon-question-sign" aria-hidden="true"></span>
-                                        <a href="#" class="{% if editable %}editable-language{% endif %} do-you-know persistant"
-                                            data-name="language"
-                                            data-type="select2" data-pk="{{footprint.id}}" data-value=""
-                                            data-params="{csrfmiddlewaretoken:'{{csrf_token}}'}" 
-                                            data-url="/api/footprint/{{footprint.id}}/">the language(s) of the footprint?</a>
-                                    </li>
-                                {% endif %}
-
-                                <li class="fixed"><span class="glyphicon glyphicon-question-sign" aria-hidden="true"></span>
-                                    <a href="#" class="{% if editable %}editable-actor{% endif %} do-you-know persistant" data-name="actor"
-                                        data-template="#xeditable-actor-form" 
-                                        data-type="actor" data-pk="{{footprint.id}}" data-value=""
-                                        data-params="{csrfmiddlewaretoken:'{{csrf_token}}'}" 
-                                        data-url="/footprint/actor/{{footprint.id}}/add/">people related to this footprint, e.g. sellers, owners, curators?</a>
-                                </li>
-
-                                {% if footprint.medium_description == None or footprint.medium_description == '' %}
-                                    <li><span class="glyphicon glyphicon-question-sign" aria-hidden="true"></span>
-                                        <a href="#" class="{% if editable %}editable{% endif %} do-you-know persistant"
-                                            data-name="medium_description" data-value=""                                         
-                                            data-type="text" data-pk="{{footprint.id}}"
-                                            data-params="{csrfmiddlewaretoken:'{{csrf_token}}'}"
-                                            data-url="/api/footprint/{{footprint.id}}/">details about the evidence type, e.g. a catalog title?</a>
-                                    </li>
-                                {% endif %}
-
-                                {% if footprint.call_number == None or footprint.call_number == '' %}
-                                    <li><span class="glyphicon glyphicon-question-sign" aria-hidden="true"></span>
-                                    <a href="#" class="{% if editable %}editable{% endif %} do-you-know persistant" data-name="call_number"
-                                        data-type="text" data-pk="{{footprint.id}}"
-                                        data-params="{csrfmiddlewaretoken:'{{csrf_token}}'}" 
-                                        data-value=""
-                                        data-url="/api/footprint/{{footprint.id}}/">the call number of the evidence?</a>
-                                    </li>
-                                {% endif %}
-                                {% if not footprint.notes %}
-                                    <li><span class="glyphicon glyphicon-question-sign" aria-hidden="true"></span>
-                                        <a href="#" class="editable do-you-know persistant" data-name="notes"
-                                           data-type="textarea" data-pk="{{footprint.id}}" data-value=""
-                                           data-params="{csrfmiddlewaretoken:'{{csrf_token}}'}"
-                                           data-url="/api/footprint/{{footprint.id}}/">any additional notes, clarifications, deductions or oddities?</a>
-                                    </li>
-                                {% endif %}
-                            </ul>
-                        </dd>
-                    </dl>
-                    {% endif %}
-                </div>
-
-                <div class="breadcrumb">THE BOOK</div>
-                <dl class="dl-horizontal">
-                    <div class="description-list writtenwork-title-container" {% if not work.title %}style="display: none"{% endif %}> 
-                        <dt>Title</dt>
-                        <dd><a href="#" class="{% if editable %}editable{% else %}readonly{% endif %}"
-                                data-attribute-name="title"  data-name="title"
-                                data-type="text" data-pk="{{work.id}}"
-                                data-params="{csrfmiddlewaretoken:'{{csrf_token}}'}" 
-                                data-url="/api/writtenwork/{{work.id}}/">{{work.title}}</a>
-                        </dd>
-                    </div>
-                    <div class="description-list writtenwork-author-container">
-                        {% for actor in work.actor.all %}
-                            <dt>{{actor.role.name}}</dt>
-                            <dd class="border-bottom">
-                                <span>{{actor.person.name}}{% if actor.alias %} as {{actor.alias}} {% endif %}</span> 
-                                <div class="pull-right">
-                                    {% if editable %}
-                                    <a href="#" class="remove-foreign-key"
-                                        data-params="{csrfmiddlewaretoken:'{{csrf_token}}'}" 
-                                        data-url="/work/actor/{{footprint.id}}/remove/{{actor.id}}/"
-                                        title="remove author">
-                                        <span class="glyphicon glyphicon-remove" aria-hidden="true"></span></a>
-                                    {% endif %}
-                                    &nbsp;
-                                    <a href="/person/{{actor.person.id}}/" title="see details" class="foreign-key">
-                                        <span class="glyphicon glyphicon-link" aria-hidden="true"></span>
-                                    </a>
-                                </div>
-                            </dd>
-                        {% endfor %}
-                    </div>
-                    <div class="description-list" {% if not work.notes %}style="display: none"{% endif %}>
-                        <dt>Notes</dt>
-                        <dd class="border-bottom">
-                            <a href="#" class="{% if editable %}editable{% else %}readonly{% endif %}"
-                                data-attribute-name="notes" data-name="notes"
-                                data-type="textarea" data-pk="{{work.id}}"
-                                data-params="{csrfmiddlewaretoken:'{{csrf_token}}'}" 
-                                data-url="/api/writtenwork/{{work.id}}/">{{work.notes|safe}}</a>
-                        </dd>
-                    </div>
-                </dl>
-                
-                <dl class="dl-horizontal">
-                    <div class="description-list" {% if not imprint.title %}style="display: none"{% endif %}>
-                        <dt>Imprint Title</dt>
-                        <dd class="border-bottom">
-                            {{imprint.title}}
-                        </dd>
-                    </div>
-                    <div class="description-list" {% if not imprint.date_of_publication %}style="display: none"{% endif %}>
-                        <dt>Publication Date</dt>
-                        <dd class="border-bottom">
-                            {{imprint.date_of_publication}}
-                        </dd>
-                    </div>
-                    <div class="description-list imprint-actor-container">
-                    {% for actor in imprint.actor.all %}
-                        <dt>{{actor.role.name}}</dt>
-                        <dd class="border-bottom">
-                            <span>{{actor.person.name}}{% if actor.alias %} as {{actor.alias}} {% endif %}</span> 
-                            <div class="pull-right">
-                                {% if editable %}
-                                <a href="#" class="remove-foreign-key"
-                                    data-params="{csrfmiddlewaretoken:'{{csrf_token}}'}" 
-                                    data-url="/imprint/actor/{{imprint.id}}/remove/{{actor.id}}/"
-                                    title="remove author">
-                                    <span class="glyphicon glyphicon-remove" aria-hidden="true"></span></a>
-                                {% endif %}
-                                &nbsp;
-                                <a href="/person/{{actor.person.id}}/" title="see details" class="foreign-key">
-                                    <span class="glyphicon glyphicon-link" aria-hidden="true"></span>
-                                </a>
-                            </div>
-                        </dd>
-                    {% endfor %}
-                    </div>
-                </dl>
-
-                {% if editable %}
-                    <dl class="dl-horizontal">
-                        <dt>Do you know...</dt>
-                        <dd>  
-                            <ul class="additional-questions">
-                                {% if not work.title %}
-                                    <li class="writtenwork-title-container">
-                                        <span class="glyphicon glyphicon-question-sign" aria-hidden="true"></span>
-                                        <a href="#" class="{% if editable %}editable{% endif %} do-you-know persistant"
-                                            data-name="title" data-type="text" data-pk="{{work.id}}" data-value=""
-                                            data-params="{csrfmiddlewaretoken:'{{csrf_token}}'}"
-                                            data-url="/api/writtenwork/{{work.id}}/">the title of the written work?</a>
-                                    </li>
-                                {% endif %}
-                                <li class="fixed"><span class="glyphicon glyphicon-question-sign" aria-hidden="true"></span>
-                                    <a href="#" class="{% if editable %}editable-author{% endif %} do-you-know persistant" data-name="actor"
-                                        data-template="#xeditable-author-form" 
-                                        data-type="actor" data-pk="{{work.id}}" data-value=""
-                                        data-params="{csrfmiddlewaretoken:'{{csrf_token}}'}" 
-                                        data-url="/work/actor/{{footprint.id}}/add/">the author(s) of the written work?</a>
-                                </li>
-                                
-                                {% if not work.notes %}
-                                    <li><span class="glyphicon glyphicon-question-sign" aria-hidden="true"></span>
-                                        <a href="#" class="editable do-you-know persistant" data-name="notes"
-                                            data-type="textarea" data-pk="{{work.id}}" data-value=""
-                                            data-params="{csrfmiddlewaretoken:'{{csrf_token}}'}"
-                                            data-url="/api/writtenwork/{{work.id}}/">any additional notes about the written work?</a>
-                                    </li>
-                                {% endif %}
-
-                            </ul>
-                       </dd>
-                    </dl>
-                {% endif %}
+                <div class="footprint-detail"></div>
+                <div class="book-detail"></div>
             </div>
             <div class="col-md-4">
-                {% with complete=footprint.percent_complete %}
-                    <ul class="list-group record-checklist">
-                        <li class="list-group-item">
-                            <h4>Record Progress</h4>
-                            <div>
-                                <div class="progress pull-left">
-                                    <div class="progress-bar" role="progressbar"
-                                        aria-valuenow="{{complete}}" aria-valuemin="0"
-                                        aria-valuemax="100" style="width: {{complete}}%;">
-                                    </div>
-                                </div>
-                                <div class="progress-report pull-right">{{complete}}% complete</div>
-                            </div>
-                            <div class="clearfix"></div>
-                        </li>
-                        <li class="list-group-item list-item-complete" data-related-fields=".evidence-type-container, .evidence-location-container">
-                            {% comment %}Required fields mean this item will always be "complete"{% endcomment %}
-                            <span class="glyphicon glyphicon-check" aria-hidden="true"></span>&nbsp;&nbsp;Footprint Evidence<br />
-                            <small>type, location</small>
-                        </li>
-                        <li class="list-group-item {% if work.title %}list-item-complete"{% endif %}
-                            data-related-fields=".writtenwork-title-container">
-                            {% if work.title %}
-                                <span class="glyphicon glyphicon-check" aria-hidden="true"></span>&nbsp;&nbsp;The Book Title
-                            {% else %}
-                                <span class="glyphicon glyphicon-unchecked" aria-hidden="true"></span>&nbsp;&nbsp;The Book Title
-                            {% endif %}
-                        </li>
-                            <li class="list-group-item {% if work.actor|length > 0 %}list-item-complete{% endif %}" data-related-fields=".writtenwork-author-container">
-                            {% if work.actor|length > 0 %}
-                                <span class="glyphicon glyphicon-check" aria-hidden="true"></span>
-                            {% else %}
-                                <span class="glyphicon glyphicon-unchecked" aria-hidden="true"></span>
-                            {% endif %}
-                            &nbsp;&nbsp;The Book Author(s)
-                        </li>
-                        <li class="list-group-item" data-related-fields="">
-                            <span class="glyphicon glyphicon-unchecked" aria-hidden="true"></span>&nbsp;&nbsp;Imprint Details<br />
-                            <small>publisher, date, location</small>
-                        </li>
-                        <li class="list-group-item {% if footprint.associated_date and footprint.place %}list-item-complete{% endif%}" 
-                            data-related-fields=".footprint-date-container, .footprint-place-container">
-                            {% if footprint.associated_date and footprint.place %}
-                                <span class="glyphicon glyphicon-check" aria-hidden="true"></span>
-                            {% else %}
-                                <span class="glyphicon glyphicon-unchecked" aria-hidden="true"></span>
-                            {% endif %}
-                            Footprint Details<br />
-                            <small>date, location</small>
-                        </li>
-                    </ul>
-                {% endwith %}
-                <div class="clearfix"></div>
-
-                {% if editable %}
-                <div class="sidebar-box">
-                    <h4>Can you connect this record?</h4>
-                    <p>Further describe your footprint by connecting similar records.</p>
-                    {% for record in records %}
-                        {{record}}
-                    {% endfor %}
-                </div>
-                {% endif %}
+                <div class="progress-detail"></div>
             </div>
         </div>
-        
+    
         <div class="modal" id="confirm-modal" tabindex="-1" role="dialog" aria-labelledby="Confirm" aria-hidden="true">
-        <div class="modal-dialog">
-            <div class="modal-content">
-                <div class="modal-header">
-                    <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-                    <h4 class="modal-title">Confirm</h4>
-                </div>
-                <div class="modal-body"></div>
-                <div class="modal-footer">
-                    <button type="button" class="btn btn-default btn-cancel" data-dismiss="modal">No</button>
-                    <button type="button" class="btn btn-primary btn-confirm">Yes</button>
+            <div class="modal-dialog">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+                        <h4 class="modal-title">Confirm</h4>
+                    </div>
+                    <div class="modal-body"></div>
+                    <div class="modal-footer">
+                        <button type="button" class="btn btn-default btn-cancel" data-dismiss="modal">No</button>
+                        <button type="button" class="btn btn-primary btn-confirm" data-dismiss="modal">Yes</button>
+                    </div>
                 </div>
             </div>
         </div>
-    </div>           
     </div>
-{% endwith %} 
 {% endblock %}

--- a/footprints/templates/xeditable/actor.html
+++ b/footprints/templates/xeditable/actor.html
@@ -1,0 +1,22 @@
+    <script type="text/template" id="xeditable-actor-form">
+        <div class="editable-actor">
+            <div class="form-group">
+                <label>Person's Name</label><br />
+                <input type="text" class="form-control" name="person-autocomplete" placeholder="Type in a person's name"></input>
+            </div>
+                    
+            <div class="form-group">
+                <label>Pseudonym or Alias (if applicable)</label><br />
+                <input type="text" class="form-control" name="actor-name" placeholder="Specify the person's alias"></select>
+            </div>
+
+            <div class="form-group">
+                <label>Role</label><br />
+                <select class="form-control" name="role" placeholder="Type in a role name">
+                    {% for role in roles.for_footprint %}
+                        <option value="{{role.id}}">{{role.name}}</option>
+                    {% endfor %}
+                </select>
+            </div>
+        </div>
+    </script>

--- a/footprints/templates/xeditable/author.html
+++ b/footprints/templates/xeditable/author.html
@@ -1,0 +1,23 @@
+    <script type="text/template" id="xeditable-author-form">
+        <div class="editable-author">
+            <div class="form-group">
+                <label>Author's Name</label><br />
+                <input type="text" class="form-control" name="person-autocomplete" placeholder="Type in a person's name"></input>
+                </div>
+                
+            <div class="form-group">
+                <label>Pseudonym or Alias (if applicable)</label><br />
+                <input type="text" class="form-control" name="actor-name" placeholder="Specify the person's alias"></select>
+            </div>
+
+            <div class="form-group" style="display: none">
+                <label>Role</label><br />
+                <select class="form-control" name="role" placeholder="Type in a role name" disabled="disabled">
+                    {% with author=roles.get_author_role %}
+                        <option value="{{author.id}}">{{author.name}}</option>
+                    {% endwith %}
+                </select>
+            </div>
+        </div>
+    </script>
+

--- a/footprints/templates/xeditable/place.html
+++ b/footprints/templates/xeditable/place.html
@@ -1,0 +1,29 @@
+    <script type="text/template" id="xeditable-place-form">
+        <div class="editable-place">
+            <div class="form-group">
+                <label>Pinpoint the location on a map</label> 
+                <div class="help-block">
+                    Search by address or click the map to drop a marker.<br />
+                    City and country values will autopopulate based on the map location.<br />
+                    These modern names can be updated if not historically accurate. 
+                </div>
+                <input class="form-control" placeholder="Search for an address..." name="address" type="text"></div>
+                <div class="map-container"></div>
+            </div>
+            <div class="row" style="width: 120%;">
+                <div class="col-md-6">
+                    <div class="form-group">
+                        <label>City</label>
+                        <input class="form-control" placeholder="City" maxlength="256" name="city" type="text">
+                        </div>
+                </div>
+                <div class="col-md-6">
+                    <div class="form-group">
+                        <label>Country</label>
+                        <input class="form-control" placeholder="Country" maxlength="256" name="country" type="text">
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </script>

--- a/footprints/templates/xeditable/publisher.html
+++ b/footprints/templates/xeditable/publisher.html
@@ -1,4 +1,4 @@
-<script type="text/template" id="xeditable-actor-form">
+<script type="text/template" id="xeditable-publisher-form">
     <div class="editable-actor">
         <div class="form-group">
             <label>Person's Name</label><br />
@@ -13,7 +13,7 @@
         <div class="form-group">
             <label>Role</label><br />
             <select class="form-control" name="role" placeholder="Type in a role name">
-                {% for role in roles.for_footprint %}
+                {% for role in roles.for_imprint %}
                     <option value="{{role.id}}">{{role.name}}</option>
                 {% endfor %}
             </select>

--- a/footprints/urls.py
+++ b/footprints/urls.py
@@ -11,14 +11,16 @@ from rest_framework import routers
 from footprints.main import views
 from footprints.main.forms import FootprintSearchForm
 from footprints.main.views import (
-    LoginView, LogoutView, TitleListView, CreateFootprintView, NameListView,
-    WrittenWorkDetailView, FootprintDetailView, PersonDetailView,
-    PlaceDetailView, FootprintViewSet, LanguageViewSet, RoleViewSet,
-    FootprintAddActorView, FootprintRemoveActorView, ExtendedDateFormatViewSet,
-    FootprintAddDateView, ActorViewSet, PersonViewSet, PlaceViewSet,
-    FootprintAddPlaceView, FootprintRemovePlaceView, WrittenWorkViewSet,
-    UserViewSet)
+    LoginView, LogoutView, FootprintAddActorView,
+    FootprintRemoveActorView, FootprintRemovePlaceView, CreateFootprintView,
+    FootprintDetailView, PersonDetailView, PlaceDetailView,
+    WrittenWorkDetailView, TitleListView, NameListView, FootprintAddPlaceView,
+    FootprintAddDateView)
 from footprints.mixins import is_staff
+from footprints.main.viewsets import (
+    BookCopyViewSet, ImprintViewSet, ActorViewSet,
+    ExtendedDateFormatViewSet, FootprintViewSet, LanguageViewSet,
+    PersonViewSet, PlaceViewSet, RoleViewSet, WrittenWorkViewSet, UserViewSet)
 
 
 admin.autodiscover()
@@ -37,6 +39,8 @@ router.register(r'place', PlaceViewSet)
 router.register(r'role', RoleViewSet)
 router.register(r'writtenwork', WrittenWorkViewSet)
 router.register(r'user', UserViewSet)
+router.register(r'book', BookCopyViewSet)
+router.register(r'imprint', ImprintViewSet)
 
 
 urlpatterns = patterns(
@@ -73,8 +77,10 @@ urlpatterns = patterns(
     url(r'^footprint/place/(?P<footprint_id>\d+)/remove/(?P<place_id>\d+)/$',
         FootprintRemovePlaceView.as_view(),
         name='footprint-remove-place-view'),
+
     url(r'^footprint/date/(?P<footprint_id>\d+)/$',
         FootprintAddDateView.as_view(), name='footprint-add-date-view'),
+
     (r'^footprint/create/$', CreateFootprintView.as_view()),
     url(r'^footprint/(?P<pk>\d+)/$',
         FootprintDetailView.as_view(), name='footprint-detail-view'),

--- a/footprints/urls.py
+++ b/footprints/urls.py
@@ -16,7 +16,8 @@ from footprints.main.views import (
     PlaceDetailView, FootprintViewSet, LanguageViewSet, RoleViewSet,
     FootprintAddActorView, FootprintRemoveActorView, ExtendedDateFormatViewSet,
     FootprintAddDateView, ActorViewSet, PersonViewSet, PlaceViewSet,
-    FootprintAddPlaceView, FootprintRemovePlaceView, WrittenWorkViewSet)
+    FootprintAddPlaceView, FootprintRemovePlaceView, WrittenWorkViewSet,
+    UserViewSet)
 from footprints.mixins import is_staff
 
 
@@ -35,6 +36,7 @@ router.register(r'person', PersonViewSet)
 router.register(r'place', PlaceViewSet)
 router.register(r'role', RoleViewSet)
 router.register(r'writtenwork', WrittenWorkViewSet)
+router.register(r'user', UserViewSet)
 
 
 urlpatterns = patterns(

--- a/footprints/urls.py
+++ b/footprints/urls.py
@@ -11,16 +11,15 @@ from rest_framework import routers
 from footprints.main import views
 from footprints.main.forms import FootprintSearchForm
 from footprints.main.views import (
-    LoginView, LogoutView, FootprintAddActorView,
-    FootprintRemoveActorView, FootprintRemovePlaceView, CreateFootprintView,
+    LoginView, LogoutView, AddActorView, CreateFootprintView,
     FootprintDetailView, PersonDetailView, PlaceDetailView,
-    WrittenWorkDetailView, TitleListView, NameListView, FootprintAddPlaceView,
-    FootprintAddDateView)
-from footprints.mixins import is_staff
+    WrittenWorkDetailView, TitleListView, NameListView,
+    AddPlaceView, AddDateView, RemoveRelatedView)
 from footprints.main.viewsets import (
     BookCopyViewSet, ImprintViewSet, ActorViewSet,
     ExtendedDateFormatViewSet, FootprintViewSet, LanguageViewSet,
     PersonViewSet, PlaceViewSet, RoleViewSet, WrittenWorkViewSet, UserViewSet)
+from footprints.mixins import is_staff
 
 
 admin.autodiscover()
@@ -66,20 +65,15 @@ urlpatterns = patterns(
         password_reset_complete, name='password_reset_complete'),
 
     auth_urls,
-    url(r'^footprint/actor/(?P<footprint_id>\d+)/add/$',
-        FootprintAddActorView.as_view(), name='footprint-add-actor-view'),
-    url(r'^footprint/actor/(?P<footprint_id>\d+)/remove/(?P<actor_id>\d+)/$',
-        FootprintRemoveActorView.as_view(),
-        name='footprint-remove-actor-view'),
+    url(r'^actor/add/$',
+        AddActorView.as_view(), name='add-actor-view'),
+    url(r'^place/add/$',
+        AddPlaceView.as_view(), name='add-place-view'),
+    url(r'^date/add/$',
+        AddDateView.as_view(), name='add-date-view'),
 
-    url(r'^footprint/place/(?P<footprint_id>\d+)/add/$',
-        FootprintAddPlaceView.as_view(), name='footprint-add-place-view'),
-    url(r'^footprint/place/(?P<footprint_id>\d+)/remove/(?P<place_id>\d+)/$',
-        FootprintRemovePlaceView.as_view(),
-        name='footprint-remove-place-view'),
-
-    url(r'^footprint/date/(?P<footprint_id>\d+)/$',
-        FootprintAddDateView.as_view(), name='footprint-add-date-view'),
+    url(r'^remove/related/$',
+        RemoveRelatedView.as_view(), name='remove-related'),
 
     (r'^footprint/create/$', CreateFootprintView.as_view()),
     url(r'^footprint/(?P<pk>\d+)/$',

--- a/media/bootstrap3-editable/js/bootstrap-editable-actor.js
+++ b/media/bootstrap3-editable/js/bootstrap-editable-actor.js
@@ -141,14 +141,10 @@ $(function(){
         
         @method input2value() 
        **/          
-       input2value: function() { 
-           return $.param({
-              name: this.$input.val(),
-              role: this.$roleselect.val(),
-              alias: this.$actorname.val()
-           });
+       input2value: function() {
+           return this.value2submit();
        },
-       
+
        /**
            @method value2submit(value) 
            @param {mixed} value

--- a/media/bootstrap3-editable/js/bootstrap-editable-place.js
+++ b/media/bootstrap3-editable/js/bootstrap-editable-place.js
@@ -34,15 +34,6 @@ Place editable input.
     $.fn.editableutils.inherit(Place, $.fn.editabletypes.abstractinput);
 
     $.extend(Place.prototype, {
-        getIconProperties: function() {
-            return {
-                url: "http://maps.gstatic.com/mapfiles/place_api/icons/geocode-71.png",
-                size: new google.maps.Size(71, 71),
-                origin: new google.maps.Point(0, 0),
-                anchor: new google.maps.Point(17, 34),
-                scaledSize: new google.maps.Size(25, 25)
-            };
-        },
         geocodePosition: function() {
             var self = this;
             self.geocoder.geocode({
@@ -72,7 +63,6 @@ Place editable input.
             }
             self.marker = new google.maps.Marker({
                 position: latlng,
-                icon: self.getIconProperties(),
                 map: self.mapInstance,
                 draggable: true,
                 animation: google.maps.Animation.DROP
@@ -98,7 +88,6 @@ Place editable input.
                 }
                 self.marker = new google.maps.Marker({
                     map: self.mapInstance,
-                    icon: self.getIconProperties(),
                     title: self.place.name,
                     position: self.place.geometry.location,
                     draggable: true,

--- a/media/bootstrap3-editable/js/bootstrap-editable.js
+++ b/media/bootstrap3-editable/js/bootstrap-editable.js
@@ -327,7 +327,7 @@ Editableform is linked with one of input types, e.g. 'text', 'select' etc.
                             params[key] = submitValue[key];
                         }
                     }
-                } else { 
+                } else {
                     //standard params
                     params['name'] = this.options.name || '';
                     params['value'] = submitValue;

--- a/media/bootstrap3-editable/js/bootstrap-editable.js
+++ b/media/bootstrap3-editable/js/bootstrap-editable.js
@@ -320,8 +320,12 @@ Editableform is linked with one of input types, e.g. 'text', 'select' etc.
                 params = {pk: pk};
                 if (this.options.namedParams) {
                     if (Array.isArray(submitValue) || typeof submitValue !== "object") {
-                        // named params
-                        params[this.options.name || 'name'] = submitValue;
+                        if (submitValue.length > 0) {
+                            // named params
+                            params[this.options.name || 'name'] = submitValue;
+                        } else {
+                            params[this.options.name || 'name'] = '';
+                        }
                     } else {
                         for (var key in submitValue) {
                             params[key] = submitValue[key];

--- a/media/css/main.css
+++ b/media/css/main.css
@@ -218,10 +218,6 @@ ul.record-checklist li.list-group-item small {
     margin-left: 22px;
 }
 
-ul.record-checklist li.list-item-complete {
-    color: #3c763d;
-    background-color: #dff0d8;
-}
 
 /** editable fields **/
 .editable-person {

--- a/media/css/main.css
+++ b/media/css/main.css
@@ -85,6 +85,10 @@ ul.wizard-tabs.has-error li.active a {
 
 
 /* Object detail pages */
+.object-detail blockquote {
+    border-left: 0;
+}
+
 .object-detail .breadcrumb {
     margin-bottom: 10px;
     background: #f6f7f8; 

--- a/media/js/app/editFootprint.js
+++ b/media/js/app/editFootprint.js
@@ -1,29 +1,34 @@
-(function() {
-
-    EditFootprintView = Backbone.View.extend({
-        events: {
-            'click a.remove-foreign-key span.glyphicon-remove': 'onConfirmRemove',
-            'click .btn-cancel': 'onCancelRemove',
-            'click .btn-confirm': 'onRemove',
-            'mouseover li.list-group-item': 'highlightRelated',
-            'mouseout li.list-group-item': 'highlightRelated'
+(function () {
+    Footprint = Backbone.Model.extend({
+        urlRoot: '/api/footprint/',
+        url: function() {
+            return this.urlRoot + this.get('id') + '/';
         },
-        getIconProperties: function() {
-            return {
-                url: "http://maps.gstatic.com/mapfiles/place_api/icons/geocode-71.png",
-                size: new google.maps.Size(71, 71),
-                origin: new google.maps.Point(0, 0),
-                anchor: new google.maps.Point(17, 34),
-                scaledSize: new google.maps.Size(25, 25)
-            };
+        parse: function(response) {
+           return response;
+        }
+    });
+
+    FootprintDetailView = Backbone.View.extend({
+        events: {
+            'click a.remove-related span.glyphicon-remove': 'confirmRemoveRelated',
         },
         initialize: function(options) {
-            _.bindAll(this, 'render',
-                'onConfirmRemove', 'onCancelRemove', 'onRemove',
-                'highlightRelated');
+            _.bindAll(this, 'context', 'refresh', 'render',
+               'confirmRemoveRelated', 'removeRelated',
+                'validatePlace');
+
+            this.baseContext = options.baseContext;
+            this.template = _.template(jQuery(options.template).html());
+            this.model.on('change', this.render);
+            
+            var html = jQuery("#place-display-template").html();
+            this.place_template = _.template(html);
             
             this.mapOptions = {
                 zoom: 10,
+                draggable: false,
+                scrollwheel: false,
                 mapTypeId: google.maps.MapTypeId.ROADMAP,
                 zoomControl: true,
                 zoomControlOptions: {
@@ -33,7 +38,51 @@
                 mapTypeControl: false,
                 streetViewControl: false
             }
-            this.mapElt = jQuery('.footprint-map')[0];
+        },
+        context: function() {
+            var ctx = this.model.toJSON();
+            for (var attrname in this.baseContext) {
+                ctx[attrname] = this.baseContext[attrname];
+            }
+            return ctx;
+        },
+        refresh: function(response, newValue) {
+            this.model.fetch();
+        },
+        render: function() {
+            var self = this;
+            
+            var markup = this.template(this.context());
+            jQuery(this.el).html(markup);
+            this.delegateEvents();
+            
+            // Initialize X-editable fields
+            jQuery(this.el).find('.editable').editable({
+                namedParams: true,
+                success: this.refresh
+            });
+            
+            jQuery('.editable-place').editable({
+                namedParams: true,
+                template: '#editable-place-form',
+                onblur: 'ignore',
+                validate: this.validatePlace,
+                success: this.refresh
+            });
+
+            jQuery('.editable-language').editable({
+                namedParams: true,
+                source: this.baseContext.all_languages,
+                select2: {
+                    multiple: true,
+                    width: 350,
+                    placeholder: 'Select language(s)',
+                    allowClear: true
+                }
+            });
+            
+            // Initialize display map
+            this.mapElt = jQuery(this.el).find('.footprint-map')[0];
             if (this.mapElt) {
                 var lat = jQuery(this.mapElt).data('latitude');
                 var lng = jQuery(this.mapElt).data('longitude');
@@ -45,179 +94,124 @@
                     this.marker = new google.maps.Marker({
                         position: latlng,
                         map: this.map,
-                        icon: this.getIconProperties(),
                         title: jQuery(this.mapElt).data('title')
                     });
                 }
             }
-
-            var html = jQuery("#actor-display-template").html();
-            this.actor_template = _.template(html);
-
-            var html = jQuery("#place-display-template").html();
-            this.place_template = _.template(html);
-                
-            var self = this;
-
-            // Modifying X-Editable default properties
-            jQuery.fn.editable.defaults.mode = 'inline';
-            jQuery.fn.editable.defaults.ajaxOptions = {
-               headers: {'X-HTTP-Method-Override': 'PATCH'}
-            };
-
-            // Initializing X-editable fields
-            jQuery('.editable').editable({
-                namedParams: true
-            });
-
-            jQuery('.editable-actor').editable({
-                namedParams: true,
-                template: '#xeditable-actor-form',
-                validate: function(value) {
-                    if (value.indexOf('name=&role') === 0) {
-                        return 'Please enter the person\'s name'; 
-                    }
-                },
-                success: function(response, newValue) {
-                    response.object = {'type': 'footprint',
-                                       'id': response.footprint.id}
-                    var html = self.actor_template(response);
-                    jQuery('div.actor-list').append(html);
-                }
-            });
-
-            jQuery('.editable-author').editable({
-                namedParams: true,
-                template: '#xeditable-author-form',
-                validate: function(value) {
-                    if (value.indexOf('name=&role') === 0) {
-                        return 'Please enter an author\'s name'; 
-                    }
-                },
-                success: function(response, newValue) {
-                    response.object = {'type': 'footprint',
-                                       'id': response.writtenwork.id}
-
-                    var html = self.actor_template(response);
-                    jQuery('.writtenwork-author-container').append(html);
-                }
-            });
-            
-            jQuery('.editable-place').editable({
-                namedParams: true,
-                template: '#editable-place-form',
-                onblur: 'ignore',
-                validate: function(values) {
-                    if (!values.hasOwnProperty('latitude') ||
-                            !values.hasOwnProperty('longitude')) {
-                        return "Please select a location on the map";
-                    } else  if (values.city.length < 1) {
-                        return "Please specify a city";
-                    } else if (values.country.length < 1) {
-                        return "Please specify a country";
-                    }
-                },
-                success: function(response, newValue) {
-                    var html = self.place_template(response);
-                    jQuery('.footprint-place').html(html);
-                    jQuery('.footprint-place').fadeIn();
-                }
-            });            
-
-            jQuery('.editable-language').editable({
-                namedParams: true,
-                source: options.languages,
-                select2: {
-                    multiple: true,
-                    width: 350,
-                    placeholder: 'Select language(s)',
-                    allowClear: true
-                }
-            });
-            
-            jQuery('.editable-medium').editable({
-                namedParams: true,
-                source: options.mediums,
-                select2: {
-                    width: 350,
-                    placeholder: 'Select evidence type'
-                }
-            });            
-
-            jQuery('.do-you-know').on('save', function(e, params) {
-                var dataName = jQuery(e.currentTarget).data('name');
-                var elts = jQuery('[data-attribute-name="' + dataName + '"]');
-                jQuery(elts).each(function(index) {
-                    if (jQuery(this).is('.editable-date')) {
-                        jQuery(this).editable('setValue', params.newValue, true);
-                        jQuery(this).attr('data-pk', params.response.associated_date);
-                        var url = jQuery(this).attr('data-url');
-                        jQuery(this).attr('data-url', url + params.response.associated_date + '/');
-                        jQuery(this).editable('option', 'pk', params.response.associated_date);
-                    } else if (jQuery(this).is('.editable, .editable-language')) {
-                        jQuery(this).editable('setValue', params.newValue, true);
-                    }
-                    jQuery(this).parents('div.description-list').show();
-                });
-                if (!jQuery(e.currentTarget).hasClass('editable-actor')) {
-                    jQuery(e.currentTarget).parents('li').fadeOut(function() {
-                        jQuery(this).remove();
-                    });
-                }
-            });
         },
-        onConfirmRemove: function(evt) {
-            this.eltToRemove = jQuery(evt.currentTarget).parents('a')[0];
-            
-            var elt = jQuery(evt.currentTarget).closest('div').prev();
-            var msg = "Are you sure you want to remove the connection to " + jQuery(elt).html() + "?";
+        confirmRemoveRelated: function(evt) {
+            var self = this;
+            var eltRemove = jQuery(evt.currentTarget).parents('a')[0];
+            var eltText = jQuery(evt.currentTarget).closest('div').prev();
+            var msg = "Are you sure you want to remove the connection to " + jQuery(eltText).html() + "?";
 
             jQuery("#confirm-modal").find('.modal-body').html(msg);
 
-            jQuery("#confirm-modal").modal({
+            var modal = jQuery("#confirm-modal").modal({
                 'show': true,
                 'backdrop': 'static',
                 'keyboard': false,
             });
+
+            jQuery('#confirm-modal .btn-confirm').one('click', function(evt) {
+                self.remove(eltRemove);
+            });
         },
-        onCancelRemove: function(evt) {
-            delete this.eltToRemove;
-        },
-        onRemove: function(evt) {
+        removeRelated: function(elt) {
             var self = this;
-            var params = jQuery(this.eltToRemove).data('params');
+            var params = jQuery(elt).data('params');
             var data = jQuery.fn.editableutils.tryParseJson(params, true);
 
             jQuery.ajax({
-                url: jQuery(this.eltToRemove).data('url'),
+                url: jQuery(elt).data('url'),
                 type: "post",
                 data: data,
-                success: function(response) {
-                    var dd = jQuery(self.eltToRemove).closest('dd')[0];
-                    var dt = jQuery(dd).prev();
-                    
-                    jQuery.each([dd, dt], function(i, elt) {
-                        jQuery(elt).fadeOut(function() {
-                            jQuery(elt).remove();
-                        });
-                    });
-                    jQuery("#confirm-modal").modal("hide");
-                    delete self.eltToRemove;
-                },
+                success: self.refresh,
                 error: function() {
                     jQuery("#confirm-modal div.error").modal("An error occurred. Please try again.");
                 }
             });
         },
-        highlightRelated: function(evt) {
-            var selector = jQuery(evt.currentTarget).data('related-fields');
-            var elts = jQuery(selector);
-            jQuery(elts).toggleClass('highlight');
+        validatePlace: function(values) {
+            if (!values.hasOwnProperty('latitude') ||
+                    !values.hasOwnProperty('longitude')) {
+                return "Please select a location on the map";
+            } else  if (values.city.length < 1) {
+                return "Please specify a city";
+            } else if (values.country.length < 1) {
+                return "Please specify a country";
+            }
+        }
+    });
+    
+    ProgressDetailView = Backbone.View.extend({
+        events: {
         },
-        unhighlightRelated: function(evt) {
-            var selector = jQuery(evt.currentTarget).data('related-fields');
-            var elts = jQuery(selector);
-            jQuery(elts).css("background-color", "white");
+        initialize: function(options) {
+            _.bindAll(this, 'render');
+            this.template = _.template(jQuery(options.template).html());
+            this.model.on('change', this.render);
+        },
+        render: function() {
+            var ctx = this.model.toJSON();
+
+            var markup = this.template(ctx);
+            jQuery(this.el).html(markup);
+            this.delegateEvents();
+        }
+    });
+    
+    BookDetailView = Backbone.View.extend({
+        events: {
+        },
+        initialize: function(options) {
+            _.bindAll(this, 'render');
+            this.template = _.template(jQuery(options.template).html());
+            this.model.on('change', this.render);
+        },
+        render: function() {
+            var ctx = this.model.toJSON();
+
+            var markup = this.template(ctx);
+            jQuery(this.el).html(markup);
+            this.delegateEvents();
+        }
+    });
+    
+    FootprintView = Backbone.View.extend({
+        events: {
+        },
+        initialize: function(options) {
+            //_.bindAll(this, 'initialRender', 'render');
+            
+            // Modifying X-Editable default properties
+            jQuery.fn.editable.defaults.mode = 'inline';
+            jQuery.fn.editable.defaults.ajaxOptions = {
+               headers: {'X-HTTP-Method-Override': 'PATCH'}
+            };
+            
+            this.model = new window.Footprint({id: options.footprint.id});
+
+            // create child views for each page area 
+            this.detailView = new FootprintDetailView({
+                el: jQuery(this.el).find(".footprint-detail"),
+                model: this.model,
+                baseContext: options.baseContext,
+                template: options.detailTemplate
+            });
+            this.bookView = new BookDetailView({
+                el: jQuery(this.el).find(".book-detail"),
+                model: this.model,
+                baseContext: options.baseContext,
+                template: options.bookTemplate
+            });
+            this.progressView = new ProgressDetailView({
+                el: jQuery(this.el).find(".progress-detail"),
+                model: this.model,
+                baseContext: options.baseContext,
+                template: options.progressTemplate
+            });
+            this.model.fetch();
         }
     });
 })();

--- a/media/js/app/editFootprint.js
+++ b/media/js/app/editFootprint.js
@@ -3,27 +3,99 @@
         urlRoot: '/api/footprint/',
         url: function() {
             return this.urlRoot + this.get('id') + '/';
-        },
-        parse: function(response) {
-           return response;
         }
     });
 
-    FootprintDetailView = Backbone.View.extend({
+    BookCopy = Backbone.Model.extend({
+        urlRoot: '/api/book/',
+        url: function() {
+            return this.urlRoot + this.get('id') + '/';
+        }
+    });
+    
+    FootprintBaseView = Backbone.View.extend({
         events: {
             'click a.remove-related span.glyphicon-remove': 'confirmRemoveRelated',
         },
+        context: function() {
+            var ctx = this.model.toJSON();
+            for (var attrname in this.baseContext) {
+                ctx[attrname] = this.baseContext[attrname];
+            }
+            return ctx;
+        },
+        refresh: function(response, newValue) {
+            this.model.fetch();
+        },
+        confirmRemoveRelated: function(evt) {
+            var self = this;
+            var eltRemove = jQuery(evt.currentTarget).parents('a')[0];
+            var eltText = jQuery(evt.currentTarget).closest('div').prev();
+            var msg = "Are you sure you want to remove the connection to " + jQuery(eltText).html() + "?";
+
+            jQuery("#confirm-modal").find('.modal-body').html(msg);
+
+            var modal = jQuery("#confirm-modal").modal({
+                'show': true,
+                'backdrop': 'static',
+                'keyboard': false,
+            });
+
+            jQuery('#confirm-modal .btn-confirm').one('click', function(evt) {
+                self.removeRelated(eltRemove);
+            });
+        },
+        removeRelated: function(elt) {
+            var self = this;
+            var params = jQuery(elt).data('params');
+            var data = jQuery.fn.editableutils.tryParseJson(params, true);
+
+            jQuery.ajax({
+                url: jQuery(elt).data('url'),
+                type: "post",
+                data: data,
+                success: self.refresh,
+                error: function() {
+                    jQuery("#confirm-modal div.error").modal("An error occurred. Please try again.");
+                }
+            });
+        },
+        validate: function(values) {
+            if (values.length < 1) {
+                return 'This field is required';
+            }
+        },
+        validateActor: function(values) {
+            if (!values.hasOwnProperty('person_name') ||
+                    values.person_name.length < 1) {
+                return 'Please enter the person\'s name';
+            } else if (!values.hasOwnProperty('role') ||
+                           values.role.length < 1) {
+                return 'Please select a role';
+            }
+        },
+        validatePlace: function(values) {
+            if (!values.hasOwnProperty('latitude') ||
+                    !values.hasOwnProperty('longitude')) {
+                return "Please select a location on the map";
+            } else  if (values.city.length < 1) {
+                return "Please specify a city";
+            } else if (values.country.length < 1) {
+                return "Please specify a country";
+            }
+        }
+    });
+    
+    FootprintDetailView = FootprintBaseView.extend({
         initialize: function(options) {
             _.bindAll(this, 'context', 'refresh', 'render',
                'confirmRemoveRelated', 'removeRelated',
-                'validatePlace');
+               'validate', 'validatePlace', 'validateActor');
 
             this.baseContext = options.baseContext;
             this.template = _.template(jQuery(options.template).html());
             this.model.on('change', this.render);
-            
-            var html = jQuery("#place-display-template").html();
-            this.place_template = _.template(html);
+            this.model.fetch();
             
             this.mapOptions = {
                 zoom: 10,
@@ -39,16 +111,6 @@
                 streetViewControl: false
             }
         },
-        context: function() {
-            var ctx = this.model.toJSON();
-            for (var attrname in this.baseContext) {
-                ctx[attrname] = this.baseContext[attrname];
-            }
-            return ctx;
-        },
-        refresh: function(response, newValue) {
-            this.model.fetch();
-        },
         render: function() {
             var self = this;
             
@@ -61,7 +123,13 @@
                 namedParams: true,
                 success: this.refresh
             });
-            
+
+            jQuery(this.el).find('.editable-required').editable({
+                namedParams: true,
+                success: this.refresh,
+                validate: this.validate
+            });
+
             jQuery('.editable-place').editable({
                 namedParams: true,
                 template: '#editable-place-form',
@@ -78,7 +146,26 @@
                     width: 350,
                     placeholder: 'Select language(s)',
                     allowClear: true
-                }
+                },
+                success: this.refresh
+            });
+            
+            jQuery('.editable-actor').editable({
+                namedParams: true,
+                template: '#xeditable-actor-form',
+                validate: this.validateActor,
+                success: this.refresh
+            });
+            
+            jQuery('.editable-medium').editable({
+                namedParams: true,
+                source: this.baseContext.all_mediums,
+                select2: {
+                    width: 350,
+                    placeholder: 'Select evidence type'
+                },
+                validate: this.validate,
+                success: this.refresh
             });
             
             // Initialize display map
@@ -98,120 +185,77 @@
                     });
                 }
             }
-        },
-        confirmRemoveRelated: function(evt) {
-            var self = this;
-            var eltRemove = jQuery(evt.currentTarget).parents('a')[0];
-            var eltText = jQuery(evt.currentTarget).closest('div').prev();
-            var msg = "Are you sure you want to remove the connection to " + jQuery(eltText).html() + "?";
-
-            jQuery("#confirm-modal").find('.modal-body').html(msg);
-
-            var modal = jQuery("#confirm-modal").modal({
-                'show': true,
-                'backdrop': 'static',
-                'keyboard': false,
-            });
-
-            jQuery('#confirm-modal .btn-confirm').one('click', function(evt) {
-                self.remove(eltRemove);
-            });
-        },
-        removeRelated: function(elt) {
-            var self = this;
-            var params = jQuery(elt).data('params');
-            var data = jQuery.fn.editableutils.tryParseJson(params, true);
-
-            jQuery.ajax({
-                url: jQuery(elt).data('url'),
-                type: "post",
-                data: data,
-                success: self.refresh,
-                error: function() {
-                    jQuery("#confirm-modal div.error").modal("An error occurred. Please try again.");
-                }
-            });
-        },
-        validatePlace: function(values) {
-            if (!values.hasOwnProperty('latitude') ||
-                    !values.hasOwnProperty('longitude')) {
-                return "Please select a location on the map";
-            } else  if (values.city.length < 1) {
-                return "Please specify a city";
-            } else if (values.country.length < 1) {
-                return "Please specify a country";
-            }
         }
     });
-    
-    ProgressDetailView = Backbone.View.extend({
+
+    BookDetailView = FootprintBaseView.extend({
         events: {
         },
         initialize: function(options) {
             _.bindAll(this, 'render');
+            
+            this.baseContext = options.baseContext;
             this.template = _.template(jQuery(options.template).html());
             this.model.on('change', this.render);
+            this.model.fetch();
         },
         render: function() {
-            var ctx = this.model.toJSON();
-
-            var markup = this.template(ctx);
+            var markup = this.template(this.context());
             jQuery(this.el).html(markup);
             this.delegateEvents();
-        }
-    });
-    
-    BookDetailView = Backbone.View.extend({
-        events: {
-        },
-        initialize: function(options) {
-            _.bindAll(this, 'render');
-            this.template = _.template(jQuery(options.template).html());
-            this.model.on('change', this.render);
-        },
-        render: function() {
-            var ctx = this.model.toJSON();
-
-            var markup = this.template(ctx);
-            jQuery(this.el).html(markup);
-            this.delegateEvents();
+            
+            // Initialize X-editable fields
+            jQuery(this.el).find('.editable').editable({
+                namedParams: true,
+                success: this.refresh
+            });
         }
     });
     
     FootprintView = Backbone.View.extend({
-        events: {
-        },
         initialize: function(options) {
-            //_.bindAll(this, 'initialRender', 'render');
+            _.bindAll(this, 'context', 'render');
             
             // Modifying X-Editable default properties
             jQuery.fn.editable.defaults.mode = 'inline';
             jQuery.fn.editable.defaults.ajaxOptions = {
-               headers: {'X-HTTP-Method-Override': 'PATCH'}
+                headers: {'X-HTTP-Method-Override': 'PATCH'}
             };
             
-            this.model = new window.Footprint({id: options.footprint.id});
-
+            this.footprint = new Footprint({id: options.footprint.id});
+            this.bookCopy = new BookCopy({id: options.book_copy.id});
+            
+            this.footprint.on('change', this.render);
+            this.bookCopy.on('change', this.render);
+            
+            this.baseContext = options.baseContext;
+            this.elProgress = jQuery(this.el).find(".progress-detail");
+            this.template = _.template(jQuery(options.progressTemplate).html());
+            
             // create child views for each page area 
             this.detailView = new FootprintDetailView({
                 el: jQuery(this.el).find(".footprint-detail"),
-                model: this.model,
+                model: this.footprint,
                 baseContext: options.baseContext,
                 template: options.detailTemplate
             });
             this.bookView = new BookDetailView({
                 el: jQuery(this.el).find(".book-detail"),
-                model: this.model,
+                model: this.bookCopy,
                 baseContext: options.baseContext,
                 template: options.bookTemplate
             });
-            this.progressView = new ProgressDetailView({
-                el: jQuery(this.el).find(".progress-detail"),
-                model: this.model,
-                baseContext: options.baseContext,
-                template: options.progressTemplate
-            });
-            this.model.fetch();
+        },
+        context: function() {
+            var ctx = this.baseContext;
+            ctx.footprint = this.footprint.toJSON();
+            ctx.book = this.bookCopy.toJSON();
+            return ctx;
+        },
+        render: function() {
+            var ctx = this.context();
+            var markup = this.template(ctx);
+            jQuery(this.elProgress).html(markup);
         }
     });
 })();


### PR DESCRIPTION
Refactoring clientside display into a better MVC model, with the classic "model change"=="render view" setup. The code had reached a point where the ad hoc rendering was beginning to get messy. This approach will also let me very quickly put up the Person, Written Work and Place detail pages. 

The add/remove related object views were also refactored to be more generic. Both views could be made generic. This was a good first step.