### PR TITLE
Fix xeditable updates

### DIFF
--- a/footprints/main/serializers.py
+++ b/footprints/main/serializers.py
@@ -125,8 +125,9 @@ class ActorSerializer(HyperlinkedModelSerializer):
 
 
 class WrittenWorkSerializer(HyperlinkedModelSerializer):
-    actor = ActorSerializer(many=True)
-    standardized_identifier = StandardizedIdentificationSerializer(many=True)
+    actor = ActorSerializer(many=True, read_only=True)
+    standardized_identifier = StandardizedIdentificationSerializer(
+        many=True, read_only=True)
 
     class Meta:
         model = WrittenWork
@@ -136,11 +137,12 @@ class WrittenWorkSerializer(HyperlinkedModelSerializer):
 
 class ImprintSerializer(HyperlinkedModelSerializer):
     work = WrittenWorkSerializer()
-    language = LanguageSerializer(many=True)
-    actor = ActorSerializer(many=True)
+    language = LanguageSerializer(many=True, read_only=True)
+    actor = ActorSerializer(many=True, read_only=True)
     place = PlaceSerializer()
     date_of_publication = ExtendedDateFormatSerializer()
-    standardized_identifier = StandardizedIdentificationSerializer(many=True)
+    standardized_identifier = StandardizedIdentificationSerializer(
+        many=True, read_only=True)
 
     class Meta:
         model = Imprint
@@ -149,20 +151,10 @@ class ImprintSerializer(HyperlinkedModelSerializer):
                   'date_of_publication', 'actor', 'notes',
                   'standardized_identifier', 'description')
 
-    def update(self, instance, validated_data):
-        if 'language' in validated_data:
-            instance.language = validated_data['language']
-            instance.save()
-        else:
-            instance = super(ImprintSerializer, self).update(
-                instance, validated_data)
-
-        return instance
-
 
 class BookCopySerializer(HyperlinkedModelSerializer):
     imprint = ImprintSerializer()
-    owners = ActorSerializer(many=True)
+    owners = ActorSerializer(many=True, read_only=True)
 
     class Meta:
         model = BookCopy
@@ -171,10 +163,10 @@ class BookCopySerializer(HyperlinkedModelSerializer):
 
 class FootprintSerializer(HyperlinkedModelSerializer):
     associated_date = ExtendedDateFormatSerializer()
-    language = LanguageSerializer(many=True)
-    actor = ActorSerializer(many=True)
+    language = LanguageSerializer(many=True, read_only=True)
+    actor = ActorSerializer(many=True, read_only=True)
     place = PlaceSerializer()
-    digital_object = DigitalObjectSerializer(many=True)
+    digital_object = DigitalObjectSerializer(many=True, read_only=True)
     created_by = UserSerializer(read_only=True)
     last_modified_by = UserSerializer(read_only=True)
 
@@ -186,14 +178,3 @@ class FootprintSerializer(HyperlinkedModelSerializer):
                   'percent_complete', 'digital_object',
                   'created_at', 'modified_at',
                   'created_by', 'last_modified_by')
-
-    def update(self, instance, validated_data):
-        if 'language' in validated_data:
-            # all related languages are posted
-            instance.language = validated_data['language']
-            instance.save()
-        else:
-            instance = super(FootprintSerializer, self).update(
-                instance, validated_data)
-
-        return instance

--- a/footprints/main/views.py
+++ b/footprints/main/views.py
@@ -363,6 +363,23 @@ class AddIdentifierView(AddRelatedRecordView):
             return self.render_to_json_response({'success': True})
 
 
+class AddLanguageView(AddRelatedRecordView):
+
+    def post(self, *args, **kwargs):
+        the_parent = self.get_parent()
+
+        languages = self.request.POST.getlist('language')
+
+        # delete all language that are not in the posted list
+        the_parent.language.exclude(id__in=languages).delete()
+
+        # add all languages. (no-op if already exists)
+        for lid in languages:
+            the_parent.language.add(Language.objects.get(id=lid))
+
+        return self.render_to_json_response({'success': True})
+
+
 class AddPlaceView(AddRelatedRecordView):
 
     def post(self, *args, **kwargs):

--- a/footprints/settings_shared.py
+++ b/footprints/settings_shared.py
@@ -85,6 +85,7 @@ MIDDLEWARE_CLASSES = [
     'waffle.middleware.WaffleMiddleware',
     'audit_log.middleware.UserLoggingMiddleware',
     'reversion.middleware.RevisionMiddleware',
+    'footprints.main.middleware.MethodOverrideMiddleware'
 ]
 
 ROOT_URLCONF = 'footprints.urls'

--- a/footprints/settings_shared.py
+++ b/footprints/settings_shared.py
@@ -84,8 +84,7 @@ MIDDLEWARE_CLASSES = [
     'debug_toolbar.middleware.DebugToolbarMiddleware',
     'waffle.middleware.WaffleMiddleware',
     'audit_log.middleware.UserLoggingMiddleware',
-    'reversion.middleware.RevisionMiddleware',
-    'footprints.main.middleware.MethodOverrideMiddleware'
+    'reversion.middleware.RevisionMiddleware'
 ]
 
 ROOT_URLCONF = 'footprints.urls'

--- a/footprints/templates/base.html
+++ b/footprints/templates/base.html
@@ -23,6 +23,7 @@
       
         <script src="{{STATIC_URL}}jquery/js/jquery-1.10.1.min.js"></script>
         <script src="{{STATIC_URL}}tinymce/tinymce.min.js"></script>
+        <script src="{{STATIC_URL}}js/app/csrf-protection.js"></script>
         <link href="//fonts.googleapis.com/css?family=Asap:400,700,400italic" rel="stylesheet" type="text/css">
         <link href='//fonts.googleapis.com/css?family=Arvo:400,700' rel='stylesheet' type='text/css'>
 

--- a/footprints/templates/clientside/footprint.html
+++ b/footprints/templates/clientside/footprint.html
@@ -11,7 +11,6 @@
         <% if (editable) { %>
             <a href="javascript:void(0);" class="editable"
                 data-name="narrative" data-type="textarea" data-pk="<%=id%>"
-                data-params="{csrfmiddlewaretoken:'<%=csrf_token%>'}" 
                 data-url="/api/footprint/<%=id%>/"><%=narrative%></a>
         <% } else { %>
             <%=narrative%>
@@ -42,7 +41,7 @@
                                             <% if (editable) { %>
                                                 <div class="edit-digital-object" style="display: none">
                                                     <a href="javascript:void(0);" class="remove-related"
-                                                        data-params="{attr:'digital_object',child_id:'<%=digital_object[i].id%>',csrfmiddlewaretoken:'<%=csrf_token%>',parent_id:<%=id%>,parent_model:'footprint'}" 
+                                                        data-params="{attr:'digital_object',child_id:'<%=digital_object[i].id%>',parent_id:<%=id%>,parent_model:'footprint'}" 
                                                         data-url="/remove/related/"
                                                         title="remove image">
                                                         <span class="glyphicon glyphicon-trash" aria-hidden="true"></span>
@@ -82,13 +81,12 @@
                     <a href="javascript:void(0);" class="editable-required required"
                      data-name="edtf_format"
                      data-type="text" data-pk="<%=associated_date.id%>"
-                     data-params="{csrfmiddlewaretoken:'<%=csrf_token%>'}"
                      data-url="/api/edtf/<%=associated_date.id%>/">
                         <%=associated_date.display_format%>
                     </a>
                     <div class="pull-right">
                         <a href="javascript:void(0);" class="remove-related"
-                            data-params="{attr:'associated_date',child_id:'<%=associated_date.id%>',csrfmiddlewaretoken:'<%=csrf_token%>',parent_id:<%=id%>,parent_model:'footprint'}" 
+                            data-params="{attr:'associated_date',child_id:'<%=associated_date.id%>',parent_id:<%=id%>,parent_model:'footprint'}" 
                             data-url="/remove/related/"
                             title="remove date">
                             <span class="glyphicon glyphicon-trash" aria-hidden="true"></span>
@@ -113,7 +111,7 @@
                 <div class="pull-right">
                     <% if (editable) { %>
                         <a href="javascript:void(0);" class="remove-related"
-                            data-params="{attr:'place',child_id:'<%=place.id%>',csrfmiddlewaretoken:'<%=csrf_token%>',parent_id:<%=id%>,parent_model:'footprint'}" 
+                            data-params="{attr:'place',child_id:'<%=place.id%>',parent_id:<%=id%>,parent_model:'footprint'}" 
                             data-url="/remove/related/"
                             title="remove place">
                             <span class="glyphicon glyphicon-trash" aria-hidden="true"></span>
@@ -139,11 +137,11 @@
             <dd class="border-bottom">
                 <% if (editable) { %>
                     <a href="javascript:void(0);" class="editable-language"
-                        data-name="language"
+                        data-name="language" data-method="post"
                         data-type="select2" data-pk="<%=id%>"
                         data-value="[<% for (var i=0; i < language.length; i++) { %><%=language[i].id%><% if (i < language.length-1) { %> ,<% } }%>]"
-                        data-params="{csrfmiddlewaretoken:'<%=csrf_token%>'}"
-                        data-url="/api/footprint/<%=id%>/">
+                        data-params="{parent_id:<%=id%>,parent_model:'footprint'}"
+                        data-url="/language/add/">
                 <% } %>
                 <% for (var i=0; i < language.length; i++) { %> 
                     <%= language[i].name %><% if (i < language.length-1) { %> , <% } %>
@@ -164,7 +162,6 @@
             <% if (editable) { %>
                 <a href="javascript:void(0);" class="editable-required"
                     data-name="title" data-type="text" data-pk="<%=id%>"
-                    data-params="{csrfmiddlewaretoken:'<%=csrf_token%>'}" 
                     data-url="/api/footprint/<%=id%>/"><%=title%></a>
             <% } else { %>
                 <%=title%>
@@ -177,7 +174,7 @@
                 <div class="pull-right">
                     <% if (editable) { %>
                         <a href="javascript:void(0);" class="remove-related"
-                            data-params="{attr:'actor',child_id:'<%=actor[i].id%>',csrfmiddlewaretoken:'<%=csrf_token%>',parent_id:<%=id%>,parent_model:'footprint'}" 
+                            data-params="{attr:'actor',child_id:'<%=actor[i].id%>',parent_id:<%=id%>,parent_model:'footprint'}" 
                             data-url="/remove/related/"
                             title="remove actor">
                             <span class="glyphicon glyphicon-trash" aria-hidden="true"></span></a>
@@ -201,7 +198,6 @@
                     data-name="medium"
                     data-type="select2" data-pk="<%=id%>"
                     data-value="<%=medium%>"
-                    data-params="{csrfmiddlewaretoken:'<%=csrf_token%>'}"
                     data-url="/api/footprint/<%=id%>/"><%=medium%>
                 </a>
             <% } else { %>
@@ -223,7 +219,6 @@
                     <a href="javascript:void(0);" class="editable"
                         data-name="medium_description"
                         data-type="text" data-pk="<%=id%>"
-                        data-params="{csrfmiddlewaretoken:'<%=csrf_token%>'}" 
                         data-url="/api/footprint/<%=id%>/"><%=medium_description%></a>
                 <% } else { %>
                     <%=medium_description%>
@@ -243,7 +238,6 @@
                 <a href="javascript:void(0);" class="editable-required"
                     data-name="provenance"
                     data-type="text" data-pk="<%=id%>"
-                    data-params="{csrfmiddlewaretoken:'<%=csrf_token%>'}" 
                     data-url="/api/footprint/<%=id%>/"><%=provenance%></a>
             <% } else { %>
                 <%=provenance%>
@@ -257,7 +251,6 @@
                     <a href="javascript:void(0);" class="editable"
                         data-name="call_number"
                         data-type="text" data-pk="<%=id%>"
-                        data-params="{csrfmiddlewaretoken:'<%=csrf_token%>'}" 
                         data-url="/api/footprint/<%=id%>/"><%=call_number%></a>
                 <% } else { %>
                     <%=call_number%>
@@ -272,7 +265,6 @@
                     <a href="javascript:void(0);" class="editable"
                         data-name="notes"
                         data-type="textarea" data-pk="<%=id%>"
-                        data-params="{csrfmiddlewaretoken:'<%=csrf_token%>'}" 
                         data-url="/api/footprint/<%=id%>/"><%=notes%></a>
                 <% } else { %>
                     <%=notes%>
@@ -292,7 +284,8 @@
                             <span class="glyphicon glyphicon-asterisk" aria-hidden="true"></span>
                             <a href="javascript:void(0);" class="editable-place do-you-know persistant"
                                 data-name="place" data-pk="<%=id%>" data-type="place"
-                                data-params="{csrfmiddlewaretoken:'<%=csrf_token%>',parent_id:<%=id%>,parent_model:'footprint'}"
+                                data-method="post"
+                                data-params="{parent_id:<%=id%>,parent_model:'footprint'}"
                                 data-url="/place/add/">the place where the footprint occurred?</a>
                         </li>
                     <% } %>
@@ -300,25 +293,25 @@
                         <li><span class="glyphicon glyphicon-asterisk" aria-hidden="true"></span>
                         <a href="javascript:void(0);" class="editable do-you-know persistant editable-refresh"
                             data-name="date_string" data-type="text" data-pk="<%=id%>"
-                            data-value=""
-                            data-params="{csrfmiddlewaretoken:'<%=csrf_token%>',parent_id:<%=id%>,parent_model:'footprint',attr:'associated_date'}"
+                            data-value="" data-method="post"
+                            data-params="{parent_id:<%=id%>,parent_model:'footprint',attr:'associated_date'}"
                             data-url="/date/add/">the date when the footprint occurred?</a>
                         </li>
                     <% } %>
                     <% if (language.length < 1) { %> 
                         <li><span class="glyphicon glyphicon-asterisk" aria-hidden="true"></span>
                             <a href="javascript:void(0);" class="editable-language do-you-know persistant"
-                                data-name="language"
+                                data-name="language" data-method="post"
                                 data-type="select2" data-pk="<%=id%>" data-value=""
-                                data-params="{csrfmiddlewaretoken:'<%=csrf_token%>'}" 
-                            data-url="/api/footprint/<%=id%>/">the language(s) of the footprint?</a>
+                                data-params="{parent_id:<%=id%>,parent_model:'footprint'}"
+                                data-url="/language/add/">the language(s) of the footprint?</a>
                         </li>
                     <% } %>
                     <li class="fixed"><span class="glyphicon glyphicon-asterisk" aria-hidden="true"></span>
                         <a href="javascript:void(0);" class="editable-actor do-you-know persistant"
-                            data-name="actor" 
+                            data-name="actor" data-method="post"
                             data-type="actor" data-pk="<%=id%>" data-value=""
-                            data-params="{csrfmiddlewaretoken:'<%=csrf_token%>',parent_id:<%=id%>,parent_model:'footprint'}" 
+                            data-params="{parent_id:<%=id%>,parent_model:'footprint'}" 
                             data-url="/actor/add/">people related to this footprint, e.g. sellers, owners, curators?</a>
                     </li>
                     <% if (!medium_description || medium_description.length < 1) { %> 
@@ -326,7 +319,6 @@
                             <a href="javascript:void(0);" class="editable do-you-know persistant"
                                 data-name="medium_description" data-value=""                                         
                                 data-type="text" data-pk="<%=id%>"
-                                data-params="{csrfmiddlewaretoken:'<%=csrf_token%>'}"
                                 data-url="/api/footprint/<%=id%>/">details about the evidence, e.g. a catalog title?</a>
                         </li>
                     <% } %>
@@ -334,7 +326,6 @@
                         <li><span class="glyphicon glyphicon-asterisk" aria-hidden="true"></span>
                             <a href="javascript:void(0);" class="editable do-you-know persistant" data-name="call_number"
                                 data-type="text" data-pk="<%=id%>" data-value=""
-                                data-params="{csrfmiddlewaretoken:'<%=csrf_token%>'}" 
                                 data-url="/api/footprint/<%=id%>/">the call number of the evidence?</a>
                         </li>
                     <% } %>
@@ -342,14 +333,13 @@
                         <li><span class="glyphicon glyphicon-asterisk" aria-hidden="true"></span>
                             <a href="javascript:void(0);" class="editable do-you-know persistant" data-name="notes"
                                data-type="textarea" data-pk="<%=id%>" data-value=""
-                               data-params="{csrfmiddlewaretoken:'<%=csrf_token%>'}"
                                data-url="/api/footprint/<%=id%>/">any additional notes, clarifications, deductions or oddities?</a>
                         </li>
                     <% } %>
                     <li><span class="glyphicon glyphicon-asterisk" aria-hidden="true"></span>
                         <a href="javascript:void(0);" class="editable-digitalobject do-you-know persistant" data-name="digital_object"
-                           data-type="digitalobject" data-pk="<%=id%>" data-value=""
-                           data-params='{"csrfmiddlewaretoken":"<%=csrf_token%>","parent_id":"<%=id%>","parent_model":"footprint"}'>
+                           data-type="digitalobject" data-pk="<%=id%>" data-value="" data-method="post"
+                           data-params='{"parent_id":"<%=id%>","parent_model":"footprint"}'>
                             what the evidence looks like? Add some images
                         </a>
                     </li>
@@ -357,7 +347,6 @@
                     <li><span class="glyphicon glyphicon-asterisk" aria-hidden="true"></span>
                         <a href="javascript:void(0);" class="editable do-you-know persistant" data-name="narrative"
                            data-type="textarea" data-pk="<%=id%>" data-value=""
-                           data-params="{csrfmiddlewaretoken:'<%=csrf_token%>'}"
                            data-url="/api/footprint/<%=id%>/">a one-sentence narrative for this footprint?</a>
                         </a>
                     </li>

--- a/footprints/templates/clientside/footprint_book.html
+++ b/footprints/templates/clientside/footprint_book.html
@@ -17,7 +17,6 @@ The Literary Work
                     data-value="<%=imprint.work.title%>"
                     data-name="title" data-model-type="WrittenWork"
                     data-type="title" data-pk="<%=imprint.work.id%>"
-                    data-params="{csrfmiddlewaretoken:'<%=csrf_token%>'}"
                     data-url="/api/writtenwork/<%=imprint.work.id%>/">
                     <%=imprint.work.title%>
                 </a>
@@ -33,7 +32,7 @@ The Literary Work
             <div class="pull-right">
                 <% if (editable) { %>
                     <a href="javascript:void(0);" class="remove-related"
-                     data-params="{attr:'actor',child_id:'<%=imprint.work.actor[i].id%>',csrfmiddlewaretoken:'<%=csrf_token%>',parent_id:<%=imprint.work.id%>,parent_model:'writtenwork'}" 
+                     data-params="{attr:'actor',child_id:'<%=imprint.work.actor[i].id%>',parent_id:<%=imprint.work.id%>,parent_model:'writtenwork'}" 
                      data-url="/remove/related/"
                      title="remove author">
                         <span class="glyphicon glyphicon-trash" aria-hidden="true"></span>
@@ -48,14 +47,13 @@ The Literary Work
             <% if (editable) { %>
                 <a href="javascript:void(0);" class="editable-work-identifier"
                     data-type="identifier" data-pk="<%=imprint.work.standardized_identifier[i].id%>"
-                    data-params="{csrfmiddlewaretoken:'<%=csrf_token%>'}"
                     data-url="/api/identifier/<%=imprint.work.standardized_identifier[i].id%>/"
                     data-value="{identifier:'<%=imprint.work.standardized_identifier[i].identifier%>',identifier_type:'<%=imprint.work.standardized_identifier[i].identifier_type%>'}">
                     <%=imprint.work.standardized_identifier[i].identifier%>
                 </a>
                 <div class="pull-right">
                     <a href="javascript:void(0);" class="remove-related"
-                     data-params="{attr:'standardized_identifier',child_id:'<%=imprint.work.standardized_identifier[i].id%>',csrfmiddlewaretoken:'<%=csrf_token%>',parent_id:<%=imprint.work.id%>,parent_model:'writtenwork'}" 
+                     data-params="{attr:'standardized_identifier',child_id:'<%=imprint.work.standardized_identifier[i].id%>',parent_id:<%=imprint.work.id%>,parent_model:'writtenwork'}" 
                      data-url="/remove/related/"
                      title="remove identifier">
                         <span class="glyphicon glyphicon-trash" aria-hidden="true"></span>
@@ -78,20 +76,19 @@ The Literary Work
                         <a href="javascript:void(0);" class="editable-work-title do-you-know persistant"
                             data-model-type="WrittenWork"
                             data-name="title" data-type="title" data-pk="<%=imprint.work.id%>" data-value=""
-                            data-params="{csrfmiddlewaretoken:'<%=csrf_token%>'}"
                             data-url="/api/writtenwork/<%=imprint.work.id%>/">the standardized English title of the literary work?</a>
                     </li>
                 <% } %>
                 <li class="fixed"><span class="glyphicon glyphicon-asterisk" aria-hidden="true"></span>
                     <a href="javascript:void(0);" class="editable-author do-you-know persistant" data-name="actor"
-                        data-type="actor" data-pk="<%=imprint.work.id%>" data-value=""
-                        data-params="{csrfmiddlewaretoken:'<%=csrf_token%>',parent_id:<%=imprint.work.id%>,parent_model:'writtenwork'}" 
+                        data-type="actor" data-pk="<%=imprint.work.id%>" data-value="" data-method="post"
+                        data-params="{parent_id:<%=imprint.work.id%>,parent_model:'writtenwork'}" 
                         data-url="/actor/add/">the author(s) of the literary work?</a>
                 </li>
                 <li><span class="glyphicon glyphicon-asterisk" aria-hidden="true"></span>
-                    <a href="javascript:void(0);" class="editable-work-identifier do-you-know persistant editable-refresh"
-                        data-value="" data-type="identifier" data-pk="<%=imprint.work.id%>"
-                        data-params="{csrfmiddlewaretoken:'<%=csrf_token%>',parent_id:<%=imprint.work.id%>,parent_model:'writtenwork'}"
+                    <a href="javascript:void(0);" class="editable-work-identifier do-you-know"
+                        data-value="" data-type="identifier" data-pk="<%=imprint.work.id%>" data-method="post"
+                        data-params="{parent_id:<%=imprint.work.id%>,parent_model:'writtenwork'}"
                         data-url="/identifier/add/">the Library of Congress identifier associated with the literary work?</a>
                 </li>
            </ul>
@@ -117,7 +114,6 @@ The Literary Work
                  data-value="<%=imprint.title%>"
                  data-name="title" data-model-type="Imprint"
                  data-type="title" data-pk="<%=imprint.id%>"
-                 data-params="{csrfmiddlewaretoken:'<%=csrf_token%>'}"
                  data-url="/api/imprint/<%=imprint.id%>/">
                     <%=imprint.title%>
                 </a>
@@ -131,11 +127,11 @@ The Literary Work
         <dd class="border-bottom">
             <% if (editable) { %>
                 <a href="javascript:void(0);" class="editable-language"
-                    data-name="language"
+                    data-name="language" data-method="post"
                     data-type="select2" data-pk="<%=imprint.id%>"
                     data-value="[<% for (var i=0; i < imprint.language.length; i++) { %><%=imprint.language[i].id%><% if (i < imprint.language.length-1) { %> ,<% } }%>]"
-                    data-params="{csrfmiddlewaretoken:'<%=csrf_token%>'}"
-                    data-url="/api/imprint/<%=imprint.id%>/">
+                    data-params="{parent_id:<%=imprint.id%>,parent_model:'imprint'}"
+                    data-url="/language/add/">
             <% } %>
             <% for (var i=0; i < imprint.language.length; i++) { %> 
                 <%= imprint.language[i].name %><% if (i < imprint.language.length-1) { %> , <% } %>
@@ -152,13 +148,12 @@ The Literary Work
                 <a href="javascript:void(0);" class="editable-required"
                  data-name="edtf_format"
                  data-type="text" data-pk="<%=imprint.date_of_publication.id%>"
-                 data-params="{csrfmiddlewaretoken:'<%=csrf_token%>'}"
                  data-url="/api/edtf/<%=imprint.date_of_publication.id%>/">
                     <%=imprint.date_of_publication.display_format%>
                 </a>
                 <div class="pull-right">
                 <a href="javascript:void(0);" class="remove-related"
-                    data-params="{attr:'date_of_publication',child_id:'<%=imprint.date_of_publication.id%>',csrfmiddlewaretoken:'<%=csrf_token%>',parent_id:<%=imprint.id%>,parent_model:'imprint'}" 
+                    data-params="{attr:'date_of_publication',child_id:'<%=imprint.date_of_publication.id%>',parent_id:<%=imprint.id%>,parent_model:'imprint'}" 
                     data-url="/remove/related/"
                     title="remove date">
                     <span class="glyphicon glyphicon-trash" aria-hidden="true"></span>
@@ -176,7 +171,7 @@ The Literary Work
             <div class="pull-right">
                 <% if (editable) { %>
                     <a href="javascript:void(0);" class="remove-related"
-                        data-params="{attr:'place',child_id:'<%=imprint.place.id%>',csrfmiddlewaretoken:'<%=csrf_token%>',parent_id:<%=imprint.id%>,parent_model:'imprint'}" 
+                        data-params="{attr:'place',child_id:'<%=imprint.place.id%>',parent_id:<%=imprint.id%>,parent_model:'imprint'}" 
                         data-url="/remove/related/"
                         title="remove place">
                         <span class="glyphicon glyphicon-trash" aria-hidden="true"></span>
@@ -198,7 +193,7 @@ The Literary Work
             <div class="pull-right">
                 <% if (editable) { %>
                     <a href="javascript:void(0);" class="remove-related"
-                     data-params="{attr:'actor',child_id:'<%=imprint.actor[i].id%>',csrfmiddlewaretoken:'<%=csrf_token%>',parent_id:<%=imprint.id%>,parent_model:'imprint'}" 
+                     data-params="{attr:'actor',child_id:'<%=imprint.actor[i].id%>',parent_id:<%=imprint.id%>,parent_model:'imprint'}" 
                      data-url="/remove/related/"
                      title="remove author">
                         <span class="glyphicon glyphicon-trash" aria-hidden="true"></span>
@@ -213,14 +208,13 @@ The Literary Work
             <% if (editable) { %>
                 <a href="javascript:void(0);" class="editable-imprint-identifier"
                     data-type="identifier" data-pk="<%=imprint.standardized_identifier[i].id%>"
-                    data-params="{csrfmiddlewaretoken:'<%=csrf_token%>'}"
                     data-url="/api/identifier/<%=imprint.standardized_identifier[i].id%>/"
                     data-value="{identifier:'<%=imprint.standardized_identifier[i].identifier%>',identifier_type:'<%=imprint.standardized_identifier[i].identifier_type%>'}">
                     <%=imprint.standardized_identifier[i].identifier%>
                 </a>
                 <div class="pull-right">
                     <a href="javascript:void(0);" class="remove-related"
-                     data-params="{attr:'standardized_identifier',child_id:'<%=imprint.standardized_identifier[i].id%>',csrfmiddlewaretoken:'<%=csrf_token%>',parent_id:<%=imprint.id%>,parent_model:'imprint'}" 
+                     data-params="{attr:'standardized_identifier',child_id:'<%=imprint.standardized_identifier[i].id%>',parent_id:<%=imprint.id%>,parent_model:'imprint'}" 
                      data-url="/remove/related/"
                      title="remove identifier">
                         <span class="glyphicon glyphicon-trash" aria-hidden="true"></span>
@@ -238,7 +232,6 @@ The Literary Work
                 <a href="javascript:void(0);" class="editable"
                     data-name="notes"
                     data-type="textarea" data-pk="<%=imprint.id%>"
-                    data-params="{csrfmiddlewaretoken:'<%=csrf_token%>'}" 
                     data-url="/api/imprint/<%=imprint.id%>/"><%=imprint.notes%></a>
             <% } else { %>
                 <%=imprint.notes%>
@@ -257,7 +250,6 @@ The Literary Work
                     <li><span class="glyphicon glyphicon-asterisk" aria-hidden="true"></span>
                         <a href="javascript:void(0);" class="editable do-you-know persistant" data-name="notes"
                             data-type="textarea" data-pk="<%=imprint.work.id%>" data-value=""
-                            data-params="{csrfmiddlewaretoken:'<%=csrf_token%>'}"
                             data-url="/api/writtenwork/<%=imprint.work.id%>/">any additional notes about the written work?</a>
                     </li>
                 <% } %>
@@ -268,7 +260,6 @@ The Literary Work
                         <a href="javascript:void(0);" class="editable-imprint-title do-you-know persistant"
                             data-model-type="Imprint"
                             data-name="title" data-type="title" data-pk="<%=imprint.id%>" data-value=""
-                            data-params="{csrfmiddlewaretoken:'<%=csrf_token%>'}"
                             data-url="/api/imprint/<%=imprint.id%>/">the title of the imprint?</a>
                     </li>
                 <% } %>
@@ -276,18 +267,18 @@ The Literary Work
                 <% if (imprint.language.length < 1) { %> 
                     <li><span class="glyphicon glyphicon-asterisk" aria-hidden="true"></span>
                         <a href="javascript:void(0);" class="editable-language do-you-know persistant"
-                            data-name="language"
+                            data-name="language" data-method="post"
                             data-type="select2" data-pk="<%=imprint.id%>" data-value=""
-                            data-params="{csrfmiddlewaretoken:'<%=csrf_token%>'}" 
-                        data-url="/api/imprint/<%=imprint.id%>/">the language of the imprint?</a>
+                            data-params="{parent_id:<%=imprint.id%>,parent_model:'imprint'}" 
+                        data-url="/language/add/">the language of the imprint?</a>
                     </li>
                 <% } %>
                 <% if (!imprint.date_of_publication) { %> 
                     <li><span class="glyphicon glyphicon-asterisk" aria-hidden="true"></span>
                     <a href="javascript:void(0);" class="editable do-you-know persistant editable-refresh"
                         data-name="date_string" data-type="text" data-pk="<%=imprint.id%>"
-                        data-value=""
-                        data-params="{csrfmiddlewaretoken:'<%=csrf_token%>',parent_id:<%=imprint.id%>,parent_model:'imprint',attr:'date_of_publication'}"
+                        data-value="" data-method="post"
+                        data-params="{parent_id:<%=imprint.id%>,parent_model:'imprint',attr:'date_of_publication'}"
                         data-url="/date/add/">the imprint publication date?</a>
                     </li>
                 <% } %>
@@ -296,23 +287,23 @@ The Literary Work
                     <li>
                         <span class="glyphicon glyphicon-asterisk" aria-hidden="true"></span>
                         <a href="javascript:void(0);" class="editable-place do-you-know persistant"
-                            data-name="place" data-pk="<%=imprint.id%>" data-type="place"
-                            data-params="{csrfmiddlewaretoken:'<%=csrf_token%>',parent_id:<%=imprint.id%>,parent_model:'imprint'}"
+                            data-name="place" data-pk="<%=imprint.id%>" data-type="place" data-method="post"
+                            data-params="{parent_id:<%=imprint.id%>,parent_model:'imprint'}"
                             data-url="/place/add/">the imprint publication location?</a>
                     </li>
                 <% } %>
 
                 <li><span class="glyphicon glyphicon-asterisk" aria-hidden="true"></span>
                     <a href="javascript:void(0);" class="editable-imprint-identifier do-you-know persistant editable-refresh"
-                        data-value="" data-type="identifier" data-pk="<%=imprint.id%>"
-                        data-params="{csrfmiddlewaretoken:'<%=csrf_token%>',parent_id:<%=imprint.id%>,parent_model:'imprint'}"
+                        data-value="" data-type="identifier" data-pk="<%=imprint.id%>" data-method="post"
+                        data-params="{parent_id:<%=imprint.id%>,parent_model:'imprint'}"
                         data-url="/identifier/add/">a standardized identifier associated with the imprint?</a>
                 </li>
                 
                 <li class="fixed"><span class="glyphicon glyphicon-asterisk" aria-hidden="true"></span>
                     <a href="javascript:void(0);" class="editable-publisher do-you-know persistant" data-name="actor"
-                        data-type="actor" data-pk="<%=imprint.id%>" data-value=""
-                        data-params="{csrfmiddlewaretoken:'<%=csrf_token%>',parent_id:<%=imprint.id%>,parent_model:'imprint'}" 
+                        data-type="actor" data-pk="<%=imprint.id%>" data-value="" data-method="post"
+                        data-params="{parent_id:<%=imprint.id%>,parent_model:'imprint'}" 
                         data-url="/actor/add/">people associated with the imprint, e.g. printer, publisher, editor?</a>
                 </li>
                 
@@ -320,7 +311,6 @@ The Literary Work
                     <li><span class="glyphicon glyphicon-asterisk" aria-hidden="true"></span>
                         <a href="javascript:void(0);" class="editable do-you-know persistant" data-name="notes"
                             data-type="textarea" data-pk="<%=imprint.id%>" data-value=""
-                            data-params="{csrfmiddlewaretoken:'<%=csrf_token%>'}"
                             data-url="/api/imprint/<%=imprint.id%>/">any additional notes about the imprint?</a>
                     </li>
                 <% } %>

--- a/footprints/templates/main/footprint_detail.html
+++ b/footprints/templates/main/footprint_detail.html
@@ -123,7 +123,6 @@
                                    {value: '{{medium}}', text: "{{medium}}"}{% if not forloop.last %},{% endif %}
                                    {% endfor %}],
                     editable: {% if editable %}true{% else %}false{% endif %},
-                    csrf_token: '{{csrf_token}}',
                     static_url: '{{STATIC_URL}}',
                     is_bare:  {% if footprint.is_bare %}true{% else %}false{% endif %},
                     work_id: '{{footprint.book_copy.imprint.work.id}}'

--- a/footprints/urls.py
+++ b/footprints/urls.py
@@ -15,7 +15,7 @@ from footprints.main.views import (
     WrittenWorkDetailView, TitleListView, NameListView,
     AddPlaceView, AddDateView, RemoveRelatedView, FootprintListView,
     AddIdentifierView, AddDigitalObjectView, ConnectFootprintView,
-    ContactUsView)
+    ContactUsView, AddLanguageView)
 from footprints.main.viewsets import (
     BookCopyViewSet, ImprintViewSet, ActorViewSet,
     ExtendedDateFormatViewSet, FootprintViewSet, LanguageViewSet,
@@ -74,6 +74,8 @@ urlpatterns = patterns(
     auth_urls,
     url(r'^actor/add/$',
         AddActorView.as_view(), name='add-actor-view'),
+    url(r'^language/add/$',
+        AddLanguageView.as_view(), name='add-language-view'),
     url(r'^place/add/$',
         AddPlaceView.as_view(), name='add-place-view'),
     url(r'^date/add/$',
@@ -86,7 +88,8 @@ urlpatterns = patterns(
     url(r'^remove/related/$',
         RemoveRelatedView.as_view(), name='remove-related'),
 
-    (r'^footprint/create/$', CreateFootprintView.as_view()),
+    url(r'^footprint/create/$', CreateFootprintView.as_view(),
+        name='create-footprint-view'),
     url(r'^footprint/connect/(?P<pk>\d+)/$', ConnectFootprintView.as_view(),
         name='connect-footprint-view'),
 

--- a/media/bootstrap3-editable/js/bootstrap-editable.js
+++ b/media/bootstrap3-editable/js/bootstrap-editable.js
@@ -354,7 +354,7 @@ Editableform is linked with one of input types, e.g. 'text', 'select' etc.
                         url: this.options.url,
                         data: params,
                         traditional: true,
-                        type: 'POST'
+                        type: this.options.method || 'patch'
                     }, this.options.ajaxOptions));
                 }
             }
@@ -629,13 +629,14 @@ Editableform is linked with one of input types, e.g. 'text', 'select' etc.
     Note: following params could redefined in engine: bootstrap or jqueryui:
     Classes 'control-group' and 'editable-error-block' must always present!
     */      
-    $.fn.editableform.template = '<form class="form-inline editableform">'+
-    '<div class="control-group">' + 
-    '<div><div class="editable-buttons"></div>' +
-    '<div class="editable-input"></div></div>'+
-    '<div class="editable-error-block"></div>' + 
-    '</div>' + 
-    '</form>';
+    $.fn.editableform.template =
+        '<form class="form-inline editableform">'+
+        '<div class="control-group">' + 
+        '<div><div class="editable-buttons"></div>' +
+        '<div class="editable-input"></div></div>'+
+        '<div class="editable-error-block"></div>' + 
+        '</div>' + 
+        '</form>';
 
     //loading div
     $.fn.editableform.loading = '<div class="editableform-loading"></div>';

--- a/media/bootstrap3-editable/js/bootstrap-editable.js
+++ b/media/bootstrap3-editable/js/bootstrap-editable.js
@@ -354,7 +354,7 @@ Editableform is linked with one of input types, e.g. 'text', 'select' etc.
                         url: this.options.url,
                         data: params,
                         traditional: true,
-                        type: this.options.method || 'patch'
+                        type: this.options.method || 'PATCH'
                     }, this.options.ajaxOptions));
                 }
             }

--- a/media/js/app/csrf-protection.js
+++ b/media/js/app/csrf-protection.js
@@ -1,0 +1,32 @@
+// using jQuery
+function getCookie(name) {
+    var cookieValue = null;
+    if (document.cookie && document.cookie !== '') {
+        var cookies = document.cookie.split(';');
+        for (var i = 0; i < cookies.length; i++) {
+            var cookie = jQuery.trim(cookies[i]);
+            // Does this cookie string begin with the name we want?
+            if (cookie.substring(0, name.length + 1) === (name + '=')) {
+                var cookieName = cookie.substring(name.length + 1);
+                cookieValue = decodeURIComponent(cookieName);
+                break;
+            }
+        }
+    }
+    return cookieValue;
+}
+
+var csrftoken = getCookie('csrftoken');
+
+function csrfSafeMethod(method) {
+    // these HTTP methods do not require CSRF protection
+    return (/^(GET|HEAD|OPTIONS|TRACE)$/.test(method));
+}
+
+$.ajaxSetup({
+    beforeSend: function(xhr, settings) {
+        if (!csrfSafeMethod(settings.type) && !this.crossDomain) {
+            xhr.setRequestHeader('X-CSRFToken', csrftoken);
+        }
+    }
+});

--- a/media/js/app/footprint-detail.js
+++ b/media/js/app/footprint-detail.js
@@ -496,9 +496,6 @@
 
             // Modifying X-Editable default properties
             jQuery.fn.editable.defaults.mode = 'inline';
-            jQuery.fn.editable.defaults.ajaxOptions = {
-                headers: {'X-HTTP-Method-Override': 'PATCH'}
-            };
 
             this.footprint = new window.Footprint({id: options.footprint.id});
             this.bookCopy = new window.BookCopy({id: options.book_copy.id});


### PR DESCRIPTION
Resolving issues related to django-rest-framework 3.3.0 [full deprecation of X-HTTP-Method-Override](http://www.django-rest-framework.org/topics/3.3-announcement/). Footprints used the method override to ease integration between XEditable, django-rest-framework, and handle csrf authentication flows. The deprecation broke all model updates via XEditable, which to my chagrin, was not caught by any unit tests. Here's the fix:

* Remove X-HTTP-Method-Override
* Append a csrf cookie to all ajax calls. Remove csrftoken from individual XEditable calls.
* Update model serializers to correctly characterize ManyToMany relationships as read only. Independent views take care of adding & removing nested list relationships.
* Replace hacky Footprint & Imprint language update method override in favor of independent AddLanguageView.
* Allow XEditable controls to specify their http method. (PATCH or POST)
* Add a test that exercises the full api patch flow with crsf checks and multipart data