### PR TITLE
Celery setup. PMT #105639

### DIFF
--- a/footprints/main/tasks.py
+++ b/footprints/main/tasks.py
@@ -1,0 +1,6 @@
+from celery import task
+
+
+@task
+def demo_task():
+    print("this is a demo celery task")

--- a/footprints/main/views.py
+++ b/footprints/main/views.py
@@ -34,6 +34,7 @@ from footprints.mixins import (
 
 from .tasks import demo_task
 
+
 class IndexView(TemplateView):
     template_name = "main/index.html"
 

--- a/footprints/main/views.py
+++ b/footprints/main/views.py
@@ -7,7 +7,7 @@ from django.core.mail import send_mail
 from django.core.urlresolvers import reverse
 from django.db.models.fields import FieldDoesNotExist
 from django.db.models.fields.related import ManyToManyField
-from django.http.response import HttpResponseRedirect
+from django.http.response import HttpResponseRedirect, HttpResponse
 from django.shortcuts import get_object_or_404
 from django.template import loader
 from django.template.context import Context
@@ -32,6 +32,7 @@ from footprints.main.serializers import NameSerializer
 from footprints.mixins import (
     JSONResponseMixin, LoggedInMixin, EditableMixin)
 
+from .tasks import demo_task
 
 class IndexView(TemplateView):
     template_name = "main/index.html"
@@ -529,3 +530,15 @@ class ContactUsView(FormView):
         send_mail(subject, tmpl.render(Context(form_data)), sender, recipients)
 
         return super(ContactUsView, self).form_valid(form)
+
+
+class CeleryTestView(View):
+    """ demo view to test out the celery setup. You can hit this
+    and see the task print out a message in the celery worker log
+    and know that everything is going through from end to end.
+
+    once celery is doing actual work and we know everything is
+    set up properly, we can just delete this view (and the demo task)"""
+    def get(self, request):
+        demo_task.delay()
+        return HttpResponse("you should see a print in the worker logs now")

--- a/footprints/settings_shared.py
+++ b/footprints/settings_shared.py
@@ -2,6 +2,7 @@
 # Django settings for footprints project.
 import os.path
 import sys
+import djcelery
 from ccnmtlsettings.shared import common
 
 project = 'footprints'
@@ -53,8 +54,13 @@ INSTALLED_APPS += [  # noqa
     'geoposition',
     'rest_framework',
     'reversion',
+    'djcelery',
     'footprints.batch'
 ]
+
+djcelery.setup_loader()
+BROKER_URL = "amqp://guest:guest@localhost:5672//footprints"
+CELERYD_CONCURRENCY = 2
 
 CONTACT_US_EMAIL = 'footprints@columbia.edu'
 
@@ -74,6 +80,7 @@ REST_FRAMEWORK = {
 }
 
 if 'test' in sys.argv or 'jenkins' in sys.argv:
+    CELERY_ALWAYS_EAGER = True
     HAYSTACK_CONNECTIONS = {
         'default': {
             'ENGINE': 'haystack.backends.simple_backend.SimpleEngine',

--- a/footprints/urls.py
+++ b/footprints/urls.py
@@ -15,7 +15,9 @@ from footprints.main.views import (
     WrittenWorkDetailView, TitleListView, NameListView,
     AddPlaceView, AddDateView, RemoveRelatedView, FootprintListView,
     AddIdentifierView, AddDigitalObjectView, ConnectFootprintView,
-    ContactUsView, AddLanguageView, DisplayDateView, CopyFootprintView)
+    ContactUsView, AddLanguageView, DisplayDateView, CopyFootprintView,
+    CeleryTestView,
+)
 from footprints.main.viewsets import (
     BookCopyViewSet, ImprintViewSet, ActorViewSet,
     ExtendedDateViewSet, FootprintViewSet, LanguageViewSet,
@@ -130,6 +132,8 @@ urlpatterns = patterns(
 
     # Batch Import
     (r'^batch/', include('footprints.batch.urls')),
+
+    url('^celerytest/', CeleryTestView.as_view(), name='celerytest'),
 
     (r'^admin/', include(admin.site.urls)),
     url(r'^_impersonate/', include('impersonate.urls')),

--- a/requirements.txt
+++ b/requirements.txt
@@ -42,6 +42,14 @@ sqlparse==0.1.18
 contextlib2==0.5.1
 rcssmin==1.0.6
 rjsmin==1.0.12
+amqp==1.4.9
+amqplib==1.0.2
+kombu==3.0.33
+librabbitmq==1.6.1
+celery==3.1.20
+anyjson==0.3.3
+billiard==3.3.0.22
+pytz==2015.7
 
 djangowind==0.14.3
 sorl==3.1
@@ -75,6 +83,7 @@ django-geoposition==0.2.2
 django-audit-log==0.7.0
 djangorestframework==3.3.0
 djangorestframework-jsonp==1.0.2
+django-celery==3.1.17
 Unidecode==0.04.17
 django-reversion==1.9.3
 python-dateutil==2.4.2


### PR DESCRIPTION
This adds the required libraries for celery and sets up a demo task plus
a view to test it.

The broker settings for staging/prod have been set in
`local_settings.py` and salted out to the servers and the required
rabbitmq vhosts set up.

The only part missing is that there isn't a celery worker running
anywhere yet, but of course, the libraries and such added here need to
be in the code before that can happen.

If this is merged and deployed to staging you ought to be able to test
by:

* log into the staging server and manually start up a worker

```
cd /var/www/footprints/footprints/; ./manage.py celeryd \
--settings=footprints.settings_staging
```

* then just hit
  https://footprints.staging.ccnmtl.columbia.edu/celerytest/

And you should see it print in the worker console/logs.

Same thing for production. Then I can set up a deployment for a
dedicated worker process and we should be good to go.