### PR TITLE
remove django-tagging

### DIFF
--- a/footprints/settings_shared.py
+++ b/footprints/settings_shared.py
@@ -43,7 +43,6 @@ MIDDLEWARE_CLASSES += [  # noqa
 
 INSTALLED_APPS += [  # noqa
     'sorl.thumbnail',
-    'tagging',
     'typogrify',
     'bootstrapform',
     'infranil',

--- a/requirements.txt
+++ b/requirements.txt
@@ -45,7 +45,6 @@ rjsmin==1.0.12
 
 djangowind==0.14.3
 sorl==3.1
-tagging==0.3-pre
 typogrify==2.0.7
 django-indexer==0.3.0
 django-templatetag-sugar==1.0


### PR DESCRIPTION
Afaict, it's not being used anywhere. Meanwhile `django-tagging` is
super obsolete and unmaintained. It currently does not support 1.7+
style migrations, so you can't bootstrap an empty database with it in
place (ie, `createdb footprints; ./manage.py migrate` fails with errors
about missing content types).