### PR TITLE
remove django-transaction-hooks

### DIFF
--- a/footprints/settings_production.py
+++ b/footprints/settings_production.py
@@ -10,18 +10,6 @@ locals().update(
         STATIC_ROOT=STATIC_ROOT
     ))
 
-DATABASES = {
-    'default': {
-        'ENGINE': 'transaction_hooks.backends.postgresql_psycopg2',
-        'NAME': 'footprints',
-        'HOST': '',
-        'PORT': 6432,
-        'USER': '',
-        'PASSWORD': '',
-        'ATOMIC_REQUESTS': True,
-    }
-}
-
 try:
     from local_settings import *
 except ImportError:

--- a/footprints/settings_staging.py
+++ b/footprints/settings_staging.py
@@ -10,18 +10,6 @@ locals().update(
         INSTALLED_APPS=INSTALLED_APPS
     ))
 
-DATABASES = {
-    'default': {
-        'ENGINE': 'transaction_hooks.backends.postgresql_psycopg2',
-        'NAME': 'footprints',
-        'HOST': '',
-        'PORT': 6432,
-        'USER': '',
-        'PASSWORD': '',
-        'ATOMIC_REQUESTS': True,
-    }
-}
-
 try:
     from local_settings import *
 except ImportError:

--- a/requirements.txt
+++ b/requirements.txt
@@ -96,7 +96,6 @@ ccnmtlsettings==0.3.0
 funcsigs==1.0.2
 pbr==1.10.0
 mock==2.0.0
-django-transaction-hooks==0.2
 celery-haystack==0.10
 django-s3sign==0.1.3
 django-smtp-ssl==1.0


### PR DESCRIPTION
according to: https://django-transaction-hooks.readthedocs.io/en/latest/

> `django-transaction-hooks` has been merged into Django 1.9 and is now
>  a built-in feature, so this third-party library should not be used
>  with Django 1.9+.