### PR TITLE
Footprint Detail Page: Add list of related footprints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,5 @@ node_modules
 digitalobjects/
 uploads/
 .DS_Store
-2015
-2016
+20*
 wheelhouse/

--- a/footprints/main/templatetags/detailtags.py
+++ b/footprints/main/templatetags/detailtags.py
@@ -1,0 +1,8 @@
+from django import template
+
+register = template.Library()
+
+
+@register.assignment_tag
+def book_copy_footprints(fp):
+    return fp.book_copy.footprint_set.all().exclude(pk=fp.pk)

--- a/footprints/templates/clientside/footprint.html
+++ b/footprints/templates/clientside/footprint.html
@@ -1,10 +1,6 @@
 <script type="text/template" id="footprint-detail-template">
     <div class="breadcrumb">
         A Footprint
-        <div class="pull-right">
-            <a href="/writtenwork/<%=work_id%>/"><span class="glyphicon glyphicon-list-alt" aria-hidden="true"></span></a>     
-            <a href="/writtenwork/<%=work_id%>/">View All</a>
-        </div>
     </div>
     <% if (narrative && narrative.length > 0) { %>
         <blockquote class="blockquote">

--- a/footprints/templates/clientside/footprint_progress.html
+++ b/footprints/templates/clientside/footprint_progress.html
@@ -14,18 +14,4 @@
             <div class="clearfix"></div>
         </li>
     </ul>
-
-    <% if (editable && work_title.length > 0) { %>
-        <div class="sidebar-box related-footprint">
-            <h4>Related Footprints</h4>
-            <p>Create another footprint for <%= work_title %> based on this footprint.
-            Evidence, imprint and book copy information can be copied.</p>
-            <div class="pull-right">
-                <a data-toggle="modal" data-target="#add-related-footprint" href="javascript:void(0);">
-                    <span class="glyphicon glyphicon-plus-sign" aria-hidden="true"></span> Create Footprint
-                </a>
-            </div>
-            <div class="clearfix"></div>
-        </div>
-    <% } %>
 </script>

--- a/footprints/templates/clientside/footprint_progress.html
+++ b/footprints/templates/clientside/footprint_progress.html
@@ -28,27 +28,4 @@
             <div class="clearfix"></div>
         </div>
     <% } %>
-
-    <div class="sidebar-box recordkeeping">
-        <h4>Recordkeeping</h4>
-        <div>
-            <b>Last Modified</b><br />
-            <% if (footprint.last_modified_by.last_name.length > 0) { %>
-                by <%=footprint.last_modified_by.first_name%> <%=footprint.last_modified_by.last_name %><br />
-            <% } else { %>
-                by <%=footprint.last_modified_by.username%><br /> 
-            <% } %>
-            at <%=footprint.modified_at%>
-        </div>
-        <br />
-        <div>
-            <b>Created</b><br />
-            <% if (footprint.created_by.last_name.length > 0) { %>
-                by <%=footprint.created_by.first_name%> <%=footprint.created_by.last_name %><br />
-            <% } else { %>
-                by <%=footprint.created_by.username%><br /> 
-            <% } %>
-            at <%=footprint.created_at%>
-        </div>
-    </div>
 </script>

--- a/footprints/templates/clientside/footprint_recordkeeping.html
+++ b/footprints/templates/clientside/footprint_recordkeeping.html
@@ -1,0 +1,23 @@
+<script type="text/template" id="recordkeeping-template">
+    <div class="breadcrumb">Recordkeeping</div>
+    <dl class="dl-horizontal">
+        <dt>Created</dt>
+        <dd>
+            <% if (footprint.created_by.last_name.length > 0) { %>
+                by <%=footprint.created_by.first_name%> <%=footprint.created_by.last_name %>
+            <% } else { %>
+                by <%=footprint.created_by.username%>
+            <% } %>
+            at <%=footprint.created_at%>
+        </dd>
+        <dt>Last Modified</dt>
+        <dd>
+            <% if (footprint.last_modified_by.last_name.length > 0) { %>
+                by <%=footprint.last_modified_by.first_name%> <%=footprint.last_modified_by.last_name %>
+            <% } else { %>
+                by <%=footprint.last_modified_by.username%> 
+            <% } %>
+            at <%=footprint.modified_at%>
+        </dd>
+    </dl>
+</script>

--- a/footprints/templates/main/footprint_detail.html
+++ b/footprints/templates/main/footprint_detail.html
@@ -10,7 +10,7 @@
 
 {% block extrahead %}
     <link href="{{STATIC_URL}}select2-3.5.2/select2.css" rel="stylesheet" />
-    
+
     {% include "xeditable/actor.html" %}
     {% include "xeditable/author.html" %}
     {% include "xeditable/digitalobject.html" %}
@@ -27,6 +27,7 @@
     {% include "clientside/footprint_connect_confirm.html" %}
     {% include "clientside/footprint_evidence.html" %}
     {% include "clientside/footprint_progress.html" %}
+    {% include "clientside/footprint_recordkeeping.html" %}
 {% endblock %}
 
 {% block js %}
@@ -61,6 +62,7 @@
                 carouselTemplate: jQuery('#carousel-template'), 
                 progressTemplate: jQuery('#progress-sidebar-template'),
                 relatedTemplate: jQuery('#related-evidence-template'),
+                recordkeepingTemplate: jQuery('#recordkeeping-template'),
                 baseContext: {
                     all_languages: [{% for language in languages %}
                                     {value: '{{language.id}}', text: "{{language.name}}"}{% if not forloop.last %},{% endif %}
@@ -98,6 +100,7 @@
                 </h1>
                 <div class="footprint-detail" style="display: none"></div>
                 <div class="book-detail" style="display: none"></div>
+                <div class="recordkeeping object-detail" style="display: none"></div>
             </div>
             <div class="col-md-4">
                 {% if footprint.is_bare and editable %}
@@ -153,7 +156,7 @@
                 </div>
             </div>
         </div>
-        
+
         {% include "main/footprint_related.html" %}
 
     </div>

--- a/footprints/templates/main/footprint_detail.html
+++ b/footprints/templates/main/footprint_detail.html
@@ -1,5 +1,6 @@
 {% extends 'base.html' %}
 {% load compress %}
+{% load detailtags %}
 
 {% block title %}Detail{% endblock %}
 
@@ -116,7 +117,7 @@
                                     this footprint to an existing literary work, imprint or physical copy.
                                 </p>
                                 <p>
-                                    <span class="emphasis"><span class="glyphicon glyphicon-question-sign" aria-hidden="true"></span> Answer</span> 
+                                    <span class="emphasis"><span class="glyphicon glyphicon-asterisk" aria-hidden="true"></span> Answer</span> 
                                     questions about people, places and events in each section.
                                 </p>
                              </li>
@@ -124,12 +125,78 @@
                     </div>
                 {% else %}
                     <div class="progress-detail"></div>
+
+                    {% book_copy_footprints footprint as footprints %}
+                    {% with imprint=footprint.book_copy.imprint %}
+
+                    {% if footprints.count > 0 %}
+                    <div class="sidebar-box related-footprint">
+                        <h4>Related Footprints</h4>
+                            <p class="info">
+                                This physical copy of {{footprint.book_copy.imprint.display_title}}{% if imprint.publication_date or imprint.place %}, published
+                                    {% if imprint.publication_date %}
+                                        {{imprint.publication_date}}
+                                    {% endif %}
+                                    {% if imprint.place %}in {{imprint.place}}{% endif %},
+                                {% endif %}
+                                has {{footprints.count}} additional footprints.
+                            </p>
+                            <ul>
+                            {% for fp in footprints %}
+                                <li class="list-group-item">
+                                    <a href="/footprint/{{fp.id}}/" class="related-footprint-badge">
+                                        <span class="badge">{{forloop.counter}}</span>
+                                    </a>
+                                    <div class="related-footprint-info">
+                                        <div>
+                                            {{fp.associated_date|default:""}}
+                                            {% if fp.place %}{% if fp.associated_date %}, {% endif %} in {{fp.place}}{% endif %}
+                                        </div>
+                                        <div>
+                                            as {{fp.title}}&nbsp;
+                                        </div>
+                                        {% with owners=fp.owners %}
+                                        {% if owners|length > 0 %}
+                                            <div>owned by <span>
+                                            {% for owner in owners %}
+                                                {{owner.display_name}}
+                                                {% if not forloop.last %},{% endif %}
+                                            {% endfor %}
+                                            </span>
+                                            </div>
+                                        {% endif %}
+                                        {% endwith %}
+                                    </div>
+                                    <div class="clearfix"></div>
+                                </li>
+                            {% endfor %}
+                            <li class="list-group-item">
+                                <a href="/writtenwork/{{imprint.work.id}}/">
+                                    <span class="glyphicon glyphicon-book" aria-hidden="true"></span>&nbsp;</a>
+                                View all footprints for this literary work
+                            </li>
+                        </ul>
+                    </div>
+                    {% endif %}
+                    {% endwith %}
+
+                    {% if editable %}
+                        <div class="sidebar-box related-footprint">
+                            <h4>Create Footprint</h4>
+                            <p class="info">Create another footprint for {{footprint.book_copy.imprint.display_title}} based on this footprint.
+                            Evidence, imprint and book copy information can be copied.</p>
+                            <button class="btn btn-sm btn-primary pull-right" data-toggle="modal" data-target="#add-related-footprint" href="javascript:void(0);">
+                                <span class="glyphicon glyphicon-plus-sign" aria-hidden="true"></span> Create
+                            </button>
+                            <div class="clearfix"></div>
+                        </div>
+                    {% endif %}
                 {% endif %}
             </div>
         </div>
-        
+
         {% include "main/footprint_connect.html" %}
-    
+
         <div class="modal" id="confirm-modal" tabindex="-1" role="dialog" aria-labelledby="Confirm" aria-hidden="true">
             <div class="modal-dialog">
                 <div class="modal-content">

--- a/media/css/main.css
+++ b/media/css/main.css
@@ -1308,8 +1308,39 @@ span.glyphicon-question-sign {
     border-radius: 4px;
 }
 
+.sidebar-box.related-footprint ul {
+    padding-left: 0px;
+}
+
+.sidebar-box.related-footprint li:last-child {
+    border-top-width: 4px;
+} 
+
+.sidebar-box.related-footprint .list-group-item {
+    padding: 10px 10px;
+}
+
+.sidebar-box.related-footprint ul li a .badge {
+    background-color: #2e5367;
+}
+
+.sidebar-box.related-footprint ul li .related-footprint-badge {
+    width: 5%;
+    margin-right: 12px;
+    float: left;
+}
+
+.sidebar-box.related-footprint ul li .related-footprint-info {
+    width: 90%;
+    float: left;
+}
+
+.sidebar-box.related-footprint .glyphicon-book {
+    font-size: 16px;
+}
+
 .object-detail .progress-report {
-    color: #9197a3;
+    color: #737373;
     font-size: 12px;
     line-height: 16px;
     margin-top: -3px;
@@ -1405,6 +1436,10 @@ body.affix-container {
     height: 200px;
 }
 
+.object-detail .footprint-place {
+    margin-bottom: 10px;
+}
+
 .object-detail ul.record-checklist li.list-group-item small {
     margin-left: 22px;
 }
@@ -1437,6 +1472,7 @@ body.affix-container {
 
 .connect-record-prompt h4 {
     color: #836737;
+    font-size: 20px;
 }
 
 .object-detail .connect-record-container .select2-container {
@@ -1536,17 +1572,19 @@ body.affix-container {
     margin-bottom: 20px;
 }
 
-.object-detail.writtenwork .list-group-item {
+.object-detail.writtenwork .list-group-item,
+.sidebar-box.related-footprint .list-group-item {
     background-color: #f6f7f8;
     border-radius: 0;
     border: 1px solid #eee;
     margin-bottom: 0px;
+    cursor: pointer;
 }
 
+.sidebar-box.related-footprint .list-group-item:hover,
 .object-detail.writtenwork .list-group-item:hover {
     border-color: #95c0e9;
 }
-
 
 .object-detail.writtenwork .list-group-item.active,
 .object-detail.writtenwork .imprint-list-item.active {
@@ -1649,12 +1687,14 @@ body.affix-container {
 }
 
 .object-detail.footprint .connect-record-prompt span.emphasis {
-    font-size: 125%;
-    font-weight: 400;
+    font-size: 18px;
+    font-weight: 500;
+    color: #97421b;
 }
 
 .object-detail.footprint .connect-record-prompt a {
-    font-size: 125%;
+    font-size: 18px;
+    font-weight: 500;
 }
 
 .object-detail.footprint #connect-records-modal form .form-group .error-block {

--- a/media/css/main.css
+++ b/media/css/main.css
@@ -1246,13 +1246,9 @@ img.footicon {
 
 .object-detail dl dd {
     margin-left: 0;
-    padding-left: 200px;
+    padding-left: 175px;
     padding-top: 5px;
     padding-bottom: 2px;
-}
-
-.object-detail dl dd.border-bottom {
-    border-bottom: dotted 1px #ccc;
 }
 
 span.glyphicon-question-sign {
@@ -1464,7 +1460,8 @@ body.affix-container {
 }
 
 .physical-copy-detail,
-.written-work-detail {
+.written-work-detail,
+.recordkeeping {
     border-radius: 4px;
     background-image: url("../img/fp_section_bg.png");
     background-repeat: repeat;

--- a/media/js/app/footprint-detail.js
+++ b/media/js/app/footprint-detail.js
@@ -497,7 +497,8 @@
     window.FootprintView = Backbone.View.extend({
         events: {
             'click .carousel img': 'maximizeCarousel',
-            'click a.connect-records': 'connectRecords'
+            'click a.connect-records': 'connectRecords',
+            'click .list-group-item': 'clickRelatedFootprint'
         },
         initialize: function(options) {
             _.bindAll(this, 'connectRecords', 'context', 'render',
@@ -556,6 +557,11 @@
                 baseContext: options.baseContext,
                 template: options.connectTemplate
             });
+        },
+        clickRelatedFootprint: function(evt) {
+            location.href =
+                jQuery(evt.currentTarget).children('a').first().attr('href');
+            return false;
         },
         connectRecords: function() {
             var modal = jQuery(this.connectBookView.el).modal({

--- a/media/js/app/footprint-detail.js
+++ b/media/js/app/footprint-detail.js
@@ -526,6 +526,11 @@
             this.carouselTemplate =
                 _.template(jQuery(options.carouselTemplate).html());
 
+            this.elRecordkeeping =
+                jQuery(this.el).find('.recordkeeping');
+            this.recordkeepingTemplate =
+                _.template(jQuery(options.recordkeepingTemplate).html());
+
             // create child views for each page area
             this.detailView = new window.FootprintDetailView({
                 el: jQuery(this.el).find('.footprint-detail'),
@@ -569,6 +574,10 @@
 
             markup = this.relatedTemplate(ctx);
             jQuery(this.elRelated).html(markup);
+
+            markup = this.recordkeepingTemplate(ctx);
+            jQuery(this.elRecordkeeping).html(markup);
+            jQuery(this.elRecordkeeping).show();
         },
         maximizeCarousel: function(evt) {
             var self = this;


### PR DESCRIPTION
* On the detail page, add a list of related footprints for the given book copy as a right-hand sidebar.
* Move the created/modified info to the end of the page
* Move the "View All" link to the right-hand sidebar and give it a bit more text.