### PR TITLE
Add export button to /browse/footprints/ page

### DIFF
--- a/footprints/templates/main/footprint_list.html
+++ b/footprints/templates/main/footprint_list.html
@@ -1,5 +1,6 @@
 {% extends 'base.html' %}
 {% load compress %}
+{% load waffle_tags %}
 
 {% block title %}Browse{% endblock %}
 
@@ -26,6 +27,13 @@
 <div class="page-header">
   <h1>Browse Footprints</h1>
 </div>
+
+{% flag "export_csv" %}
+<form action="/browse/footprints/" method="post">
+    {% csrf_token %}
+    <button name="export">Export</button>
+</form>
+{% endflag %}
 
 <div class="object-browse">
     <div class="row tools">


### PR DESCRIPTION
This PR creates a button that will be used to export a CSV file of search results.