### PR TITLE
WrittenWorkDetail: handle extended urls

### DIFF
--- a/footprints/main/views.py
+++ b/footprints/main/views.py
@@ -244,6 +244,11 @@ class WrittenWorkDetailView(EditableMixin, DetailView):
         context['related'] = []
         context['editable'] = self.has_edit_permission(self.request.user)
         context['imprints'] = self.object.imprints()
+        context['state'] = {
+            'imprint': self.kwargs.get('imprint', None),
+            'copy': self.kwargs.get('copy', None),
+            'footprint': self.kwargs.get('footprint', None)
+        }
         return context
 
 

--- a/footprints/templates/main/writtenwork_detail.html
+++ b/footprints/templates/main/writtenwork_detail.html
@@ -33,7 +33,12 @@
                 el: jQuery('div.object-detail'),
                 work: {'id': '{{object.id}}'},
                 template: jQuery('#book-copy-template'),
-                urlBase: '{% url "writtenwork-detail-view" object.id %}'
+                urlBase: '{% url "writtenwork-detail-view" object.id %}',
+                state: {
+                    imprint: {% if state.imprint %}{{state.imprint}}{% else %}undefined{% endif %},
+                    copy: {% if state.copy %}{{state.copy}}{% else %}undefined{% endif %},
+                    footprint: {% if state.footprint %}{{state.footprint}}{% else %}undefined{% endif %},
+                }
             });
         });
     </script>

--- a/footprints/urls.py
+++ b/footprints/urls.py
@@ -101,7 +101,14 @@ urlpatterns = [
         PersonDetailView.as_view(), name='person-detail-view'),
     url(r'^place/(?P<pk>\d+)/$',
         PlaceDetailView.as_view(), name='place-detail-view'),
-    url(r'^writtenwork/(?P<pk>[-_\w]+)/$',
+    url(r'^writtenwork/(?P<pk>\d+)/(?P<imprint>\d+)/'
+        '(?P<copy>\d+)/(?P<footprint>\d+)/$',
+        WrittenWorkDetailView.as_view(), name='writtenwork-detail-view'),
+    url(r'^writtenwork/(?P<pk>\d+)/(?P<imprint>\d+)/(?P<copy>\d+)/$',
+        WrittenWorkDetailView.as_view(), name='writtenwork-detail-view'),
+    url(r'^writtenwork/(?P<pk>\d+)/(?P<imprint>\d+)/$',
+        WrittenWorkDetailView.as_view(), name='writtenwork-detail-view'),
+    url(r'^writtenwork/(?P<pk>\d+)/$',
         WrittenWorkDetailView.as_view(), name='writtenwork-detail-view'),
 
     url(r'^browse/footprints/$', FootprintListView.as_view(),

--- a/media/js/app/imprint-detail.js
+++ b/media/js/app/imprint-detail.js
@@ -23,6 +23,9 @@
             this.initializeMap();
             jQuery(window).on('resize', this.resize);
             jQuery(window).on('popstate', this.popState);
+
+            this.setState(options.state.imprint, options.state.copy,
+                options.state.footprint);
         },
         mapOptions: {
             zoom: 10,
@@ -330,14 +333,17 @@
             var fpId = evt.originalEvent.state.footprint;
             var copyId = evt.originalEvent.state.copy;
             var imprintId = evt.originalEvent.state.imprint;
+            this.setState(imprintId, copyId, fpId);
+        },
+        setState: function(imprintId, copyId, footprintId) {
             var $elt;
-            if (fpId) {
+            if (footprintId) {
                 $elt = jQuery('div.panel-collapse[data-copy-id="' +
                     copyId + '"]');
                 $elt.collapse('show');
 
                 $elt = jQuery('.list-group-item[data-footprint-id="' +
-                    fpId + '"]');
+                    footprintId + '"]');
                 $elt.addClass('active');
                 this.syncMap($elt.data('map-id'));
             } else if (copyId) {
@@ -352,6 +358,9 @@
                 $elt = jQuery('h4[data-imprint-id="' + imprintId + '"]');
                 $elt.parent().addClass('active');
                 this.syncMap($elt.data('map-id'));
+            }
+            if ($elt) {
+                this.scrollToItem($elt);
             }
         }
     });


### PR DESCRIPTION
The written work detail page can now reconstitute state for a selected imprint, copy or footprint.