### PR TITLE
Move 'Export' button.  Remove extraneous comment.

### DIFF
--- a/footprints/main/views.py
+++ b/footprints/main/views.py
@@ -289,7 +289,6 @@ class ExportFootprintListView(FootprintListView):
             (writer.writerow(row) for row in rows), content_type="text/csv"
         )
         response['Content-Disposition'] = 'attachment; filename="' + fnm + '"'
-        # pdb.set_trace()
         return response
 
 

--- a/footprints/templates/main/footprint_list.html
+++ b/footprints/templates/main/footprint_list.html
@@ -39,15 +39,15 @@
                     <button class="btn btn-white btn-search-text" type="button">
                         <span class="glyphicon glyphicon-search"></span>
                     </button>
-                    {% flag "export_csv" %}
-                    <button class="btn btn-white btn-export" type="button">
-                        Export
-                    </button>
-                    {% endflag %}
                 </span>
             </div>
         </div>
         <div class="col-md-8">
+            {% flag "export_csv" %}
+            <button class="btn btn-white btn-export" type="button">
+                Export
+            </button>
+            {% endflag %}
             {% include 'main/pagination.html' %}
         </div>
     </div>


### PR DESCRIPTION
This commit moves the 'Export' button from the input-group div to the div
containing the page.  This was done to make the export functionality
visually distinct from the search functionality.