### PR TITLE
Footprint Detail: add moderation utilities

### DIFF
--- a/footprints/main/admin.py
+++ b/footprints/main/admin.py
@@ -114,7 +114,8 @@ class FootprintAdmin(VersionAdmin):
             'fields': ('book_copy', 'medium', 'medium_description',
                        'provenance', 'title', 'language', 'place',
                        'associated_date', 'call_number', 'collection',
-                       'digital_object', 'actor', 'notes', 'narrative')
+                       'digital_object', 'actor', 'notes', 'narrative',
+                       'verified')
         }),
         ('Advanced options', {
             'classes': ('collapse',),

--- a/footprints/main/serializers.py
+++ b/footprints/main/serializers.py
@@ -194,5 +194,6 @@ class FootprintSerializer(HyperlinkedModelSerializer):
                   'provenance', 'title', 'language', 'actor', 'call_number',
                   'notes', 'associated_date', 'place', 'narrative',
                   'percent_complete', 'digital_object',
+                  'verified', 'is_flagged',
                   'created_at', 'modified_at',
                   'created_by', 'last_modified_by')

--- a/footprints/main/tests/test_views.py
+++ b/footprints/main/tests/test_views.py
@@ -1260,3 +1260,29 @@ class ModerationViewTest(TestCase):
 
         self.client.login(username=staff.username, password='test')
         self.assertEquals(self.client.get(url).status_code, 200)
+
+
+class VerifyFootprintViewTest(TestCase):
+
+    def test_post(self):
+        fp = FootprintFactory()
+        user = UserFactory()
+        staff = UserFactory(is_staff=True)
+
+        url = reverse('verify-footprint-view', kwargs={'pk': fp.id})
+        self.assertEquals(self.client.get(url).status_code, 405)
+
+        self.client.login(username=user.username, password='test')
+        self.assertEquals(self.client.get(url).status_code, 405)
+
+        self.client.login(username=staff.username, password='test')
+
+        data = {'verified': 1}
+        self.assertEquals(self.client.post(url, data).status_code, 302)
+        fp.refresh_from_db()
+        self.assertTrue(fp.verified)
+
+        data = {'verified': 0}
+        self.assertEquals(self.client.post(url, data).status_code, 302)
+        fp.refresh_from_db()
+        self.assertFalse(fp.verified)

--- a/footprints/main/views.py
+++ b/footprints/main/views.py
@@ -719,3 +719,16 @@ class ModerationView(LoggedInStaffMixin, TemplateView):
             'book_copy__imprint__standardized_identifier__identifier_type')
 
         return context
+
+
+class VerifyFootprintView(LoggedInStaffMixin, View):
+
+    def post(self, *args, **kwargs):
+        fp = get_object_or_404(Footprint, pk=kwargs.get('pk'))
+
+        verified = self.request.POST.get('verified')
+        fp.verified = verified == '1'
+        fp.save()
+
+        url = reverse('footprint-detail-view', kwargs={'pk': fp.pk})
+        return HttpResponseRedirect(url)

--- a/footprints/templates/base.html
+++ b/footprints/templates/base.html
@@ -65,7 +65,7 @@
                             <li class="dropdown">
                                 <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Manage <span class="caret"></span></a>
                                 <ul class="dropdown-menu">
-                                    <li><a href="/batch/">Import</a></li>
+                                    <li><a href="/batch/">Batch Import</a></li>
                                     <li><a href="/moderate/">Moderate</a></li>
                                 </ul>
                             </li>

--- a/footprints/templates/clientside/footprint_progress.html
+++ b/footprints/templates/clientside/footprint_progress.html
@@ -1,17 +1,65 @@
 <script type="text/template" id="progress-sidebar-template">
-    <ul class="list-group">
-        <li class="list-group-item checklist">
-            <h4>Record Checklist</h4>
-            <div>
-                <div class="progress pull-left">
-                    <div class="progress-bar" role="progressbar"
-                        aria-valuenow="<%=footprint.percent_complete%>" aria-valuemin="0"
-                        aria-valuemax="100" style="width: <%=footprint.percent_complete%>%;">
+    <% if (editable) { %>
+        <a href="#" class="pull-right integrity-flag <% if (footprint.is_flagged) { %> flagged <% } %>"
+            data-toggle="modal" data-target="#integrity-modal">
+        <% if (footprint.verified) { %>
+                <span class="glyphicon glyphicon-certificate" aria-hidden="true"></span> Verified
+        <% } else if (footprint.is_flagged) { %>
+                Flagged <span class="glyphicon glyphicon-bookmark" aria-hidden="true"></span>
+        <% } else { %>
+                <span class="glyphicon glyphicon-bookmark" aria-hidden="true"></span> Ready to verify
+        <% } %>
+        </a>
+        <div class="clearfix"></div>
+        <div class="modal" id="integrity-modal" tabindex="-1" role="dialog">
+            <div class="modal-dialog" role="document">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <h4 class="modal-title">Footprint Verification</h4>
+                    </div>
+                    <div class="modal-body">
+                        <% if (footprint.verified) { %>
+                            <p>Data experts have verified this record's information is accurate.</p>
+                        <% } else if (footprint.is_flagged) { %>
+                            <p>This footprint's data has some issues, and has not been verified.</p>
+                        <% } else { %>
+                            <p>This footprint's data appears accurate, but needs to be verified.</p>
+                        <% } %>
+
+                        <form action="" method="post">
+                            <div class="radio">
+                            <label>
+                                <input type="radio" name="verified" value="1" <% if (footprint.verified) { %>checked<% } %>>
+                                    <strong>Verify</strong> confirm this record's data is accurate
+                            </label>
+                            </div>
+                            <div class="radio">
+                            <label>
+                                <input type="radio" name="verified" value="0" <% if (!footprint.verified) { %>checked<% } %>>
+                                    <strong>Unverify</strong> mark this record's data for review
+                            </label>
+                            </div>
+                            <div class="pull-right">
+                                <button type="button" class="btn btn-default btn-cancel" data-dismiss="modal">Cancel</button>
+                                <button type="button" class="btn btn-primary btn-confirm" data-dismiss="modal">Save</button>
+                            </div>
+                            <div class="clearfix"></div>
+                        </form>
                     </div>
                 </div>
-                <div class="progress-report pull-right"><%=footprint.percent_complete%>% complete</div>
             </div>
-            <div class="clearfix"></div>
-        </li>
-    </ul>
+        </div>
+    <% } %>
+
+    <h4>Record Checklist</h4>
+    <div>
+        <div class="progress pull-left">
+            <div class="progress-bar" role="progressbar"
+                aria-valuenow="<%=footprint.percent_complete%>" aria-valuemin="0"
+                aria-valuemax="100" style="width: <%=footprint.percent_complete%>%;">
+            </div>
+        </div>
+        <div class="progress-report pull-right"><%=footprint.percent_complete%>% complete</div>
+    </div>
+    <div class="clearfix"></div>
 </script>

--- a/footprints/templates/clientside/footprint_progress.html
+++ b/footprints/templates/clientside/footprint_progress.html
@@ -1,5 +1,5 @@
 <script type="text/template" id="progress-sidebar-template">
-    <% if (editable) { %>
+    <% if (is_moderator) { %>
         <a href="#" class="pull-right integrity-flag <% if (footprint.is_flagged) { %> flagged <% } %>"
             data-toggle="modal" data-target="#integrity-modal">
         <% if (footprint.verified) { %>
@@ -26,7 +26,7 @@
                             <p>This footprint's data appears accurate, but needs to be verified.</p>
                         <% } %>
 
-                        <form action="" method="post">
+                        <form action="/footprint/verify/<%=footprint.id%>/" method="post">{% csrf_token %}
                             <div class="radio">
                             <label>
                                 <input type="radio" name="verified" value="1" <% if (footprint.verified) { %>checked<% } %>>
@@ -41,7 +41,7 @@
                             </div>
                             <div class="pull-right">
                                 <button type="button" class="btn btn-default btn-cancel" data-dismiss="modal">Cancel</button>
-                                <button type="button" class="btn btn-primary btn-confirm" data-dismiss="modal">Save</button>
+                                <button type="submit" class="btn btn-primary btn-confirm">Save</button>
                             </div>
                             <div class="clearfix"></div>
                         </form>

--- a/footprints/templates/main/footprint_detail.html
+++ b/footprints/templates/main/footprint_detail.html
@@ -133,7 +133,7 @@
                             <h4>Related Footprints</h4>
                                 {% if footprints.exists %}
                                 <p class="info">
-                                    This physical copy of {{footprint.book_copy.imprint.display_title}}{% if imprint.publication_date or imprint.place %}, published
+                                    This physical copy of <strong>{{footprint.book_copy.imprint.display_title}}</strong>{% if imprint.publication_date or imprint.place %}, published
                                         {% if imprint.publication_date %}
                                             {{imprint.publication_date}}
                                         {% endif %}
@@ -184,8 +184,7 @@
                     {% if editable %}
                         <div class="sidebar-box related-footprint">
                             <h4>Create Footprint</h4>
-                            <p class="info">Create another footprint for {{footprint.book_copy.imprint.display_title}} based on this footprint.
-                            Evidence, imprint and book copy information can be copied.</p>
+                            <p class="info">Create a new footprint based on this literary work, imprint, book copy and evidence.</p>
                             <button class="btn btn-sm btn-primary pull-right" data-toggle="modal" data-target="#add-related-footprint" href="javascript:void(0);">
                                 <span class="glyphicon glyphicon-plus-sign" aria-hidden="true"></span> Create
                             </button>

--- a/footprints/templates/main/footprint_detail.html
+++ b/footprints/templates/main/footprint_detail.html
@@ -75,7 +75,8 @@
                     static_url: '{{STATIC_URL}}',
                     is_bare:  {% if footprint.is_bare %}true{% else %}false{% endif %},
                     work_id: '{{footprint.book_copy.imprint.work.id}}',
-                    work_title: '{{footprint.book_copy.imprint.work.title}}'
+                    work_title: '{{footprint.book_copy.imprint.work.title}}',
+                    is_moderator: {% if request.user.is_staff %}true{% else %}false{% endif %}
                 }
             });
 

--- a/footprints/urls.py
+++ b/footprints/urls.py
@@ -17,7 +17,7 @@ from footprints.main.views import (
     AddPlaceView, AddDateView, RemoveRelatedView, FootprintListView,
     AddIdentifierView, AddDigitalObjectView, ConnectFootprintView,
     ContactUsView, AddLanguageView, DisplayDateView, CopyFootprintView,
-    SignS3View, ExportFootprintListView, ModerationView)
+    SignS3View, ExportFootprintListView, ModerationView, VerifyFootprintView)
 from footprints.main.viewsets import (
     BookCopyViewSet, ImprintViewSet, ActorViewSet,
     ExtendedDateViewSet, FootprintViewSet, LanguageViewSet,
@@ -94,6 +94,8 @@ urlpatterns = [
         name='connect-footprint-view'),
     url(r'^footprint/copy/(?P<pk>\d+)/$', CopyFootprintView.as_view(),
         name='copy-footprint-view'),
+    url(r'^footprint/verify/(?P<pk>\d+)/$', VerifyFootprintView.as_view(),
+        name='verify-footprint-view'),
 
     url(r'^footprint/(?P<pk>\d+)/$',
         FootprintDetailView.as_view(), name='footprint-detail-view'),

--- a/media/css/main.css
+++ b/media/css/main.css
@@ -1299,12 +1299,16 @@ span.glyphicon-question-sign {
     width: 65%;
 }
 
-.list-group-item.checklist {
+.object-detail .flagged {
+    color: #97421b;
+}
+
+.object-detail .progress-detail {
     background-image: url("../img/fp_section_bg.png");
     background-repeat: repeat;
     box-shadow: none;
     margin: 0 0 20px 0;
-    padding: 10px 20px 20px 20px;
+    padding: 5px 20px 20px 20px;
     border: none;
     border-radius: 4px;
 }


### PR DESCRIPTION
* Indicate the current Footprint's state: verified, unverified w/errors (flagged), unverified without errors (ready to verify)
* Add utility to allow moderator to verify a footprint.

<img width="371" alt="screen shot 2017-02-23 at 1 40 43 pm" src="https://cloud.githubusercontent.com/assets/141369/23273610/b657745a-f9cd-11e6-9141-f1bb598221fe.png">
<img width="628" alt="screen shot 2017-02-23 at 1 40 33 pm" src="https://cloud.githubusercontent.com/assets/141369/23273613/b83498fc-f9cd-11e6-86bb-6d04bf242578.png">
