### PR TITLE
Add SuperModerator role

### DIFF
--- a/footprints/batch/views.py
+++ b/footprints/batch/views.py
@@ -17,10 +17,11 @@ from footprints.batch.models import BatchJob, BatchRow
 from footprints.batch.templatetags.batchrowtags import validate_field_value
 from footprints.main.models import Imprint, BookCopy, Footprint, \
     Role, ExtendedDate, Actor, Place
-from footprints.mixins import LoggedInStaffMixin, JSONResponseMixin
+from footprints.mixins import (
+    JSONResponseMixin, LoggedInMixin, BatchAccessMixin)
 
 
-class BatchJobListView(LoggedInStaffMixin, FormView):
+class BatchJobListView(LoggedInMixin, BatchAccessMixin, FormView):
     template_name = 'batch/batchjob_list.html'
     form_class = CreateBatchJobForm
 
@@ -46,7 +47,7 @@ class BatchJobListView(LoggedInStaffMixin, FormView):
         return super(BatchJobListView, self).form_valid(form)
 
 
-class BatchJobDetailView(LoggedInStaffMixin, DetailView):
+class BatchJobDetailView(LoggedInMixin, BatchAccessMixin, DetailView):
     model = BatchJob
 
     def get_context_data(self, **kwargs):
@@ -55,7 +56,7 @@ class BatchJobDetailView(LoggedInStaffMixin, DetailView):
         return context
 
 
-class BatchJobUpdateView(LoggedInStaffMixin, View):
+class BatchJobUpdateView(LoggedInMixin, BatchAccessMixin, View):
 
     INVALID_LOCATION = (
         'Location [{}] lookup failed at the {} level [id={}]')
@@ -203,12 +204,13 @@ class BatchJobUpdateView(LoggedInStaffMixin, View):
             reverse('batchjob-detail-view', kwargs={'pk': pk}))
 
 
-class BatchJobDeleteView(LoggedInStaffMixin, DeleteView):
+class BatchJobDeleteView(LoggedInMixin, BatchAccessMixin, DeleteView):
     model = BatchJob
     success_url = reverse_lazy('batchjob-list-view')
 
 
-class BatchRowUpdateView(LoggedInStaffMixin, JSONResponseMixin, View):
+class BatchRowUpdateView(LoggedInMixin, BatchAccessMixin,
+                         JSONResponseMixin, View):
     def post(self, *args, **kwargs):
         pk = kwargs.get('pk', None)
         row = get_object_or_404(BatchRow, pk=pk)
@@ -229,7 +231,7 @@ class BatchRowUpdateView(LoggedInStaffMixin, JSONResponseMixin, View):
         })
 
 
-class BatchRowDeleteView(LoggedInStaffMixin, DeleteView):
+class BatchRowDeleteView(LoggedInMixin, BatchAccessMixin, DeleteView):
     model = BatchRow
 
     def get_success_url(self):

--- a/footprints/main/context_processors.py
+++ b/footprints/main/context_processors.py
@@ -1,0 +1,10 @@
+from footprints.mixins import BatchAccessMixin, ModerationAccessMixin
+
+
+def permissions(request):
+    return {
+        'can_import':
+            request.user.has_perms(BatchAccessMixin.permission_required),
+        'can_moderate':
+            request.user.has_perms(ModerationAccessMixin.permission_required)
+    }

--- a/footprints/main/tests/factories.py
+++ b/footprints/main/tests/factories.py
@@ -1,6 +1,6 @@
 import os
 
-from django.contrib.auth.models import User
+from django.contrib.auth.models import User, Group, Permission
 import factory
 
 from footprints.main.models import (
@@ -13,11 +13,41 @@ from footprints.main.models import (
 TEST_MEDIA_PATH = os.path.join(os.path.dirname(__file__), 'test.txt')
 
 
+BATCH_PERMISSIONS = [
+    'add_batchjob', 'change_batchjob', 'delete_batchjob',
+    'add_batchrow', 'change_batchrow', 'delete_batchrow']
+
+
+MODERATION_PERMISSIONS = ['can_moderate']
+
+
 class UserFactory(factory.DjangoModelFactory):
     class Meta:
         model = User
     username = factory.Sequence(lambda n: "user%03d" % n)
     password = factory.PostGenerationMethodCall('set_password', 'test')
+
+    @factory.post_generation
+    def group(self, create, extracted, **kwargs):
+        if not create:
+            return
+
+        if extracted:
+            self.groups.add(extracted)
+
+
+class GroupFactory(factory.DjangoModelFactory):
+    class Meta:
+        model = Group
+
+    @factory.post_generation
+    def permissions(self, create, extracted, **kwargs):
+        if not create:
+            return
+
+        if extracted:
+            lst = list(Permission.objects.filter(codename__in=extracted))
+            self.permissions.add(*lst)
 
 
 class ExtendedDateFactory(factory.DjangoModelFactory):

--- a/footprints/main/views.py
+++ b/footprints/main/views.py
@@ -36,7 +36,7 @@ from footprints.main.models import (
 from footprints.main.serializers import NameSerializer
 from footprints.main.templatetags.moderation import moderation_footprints
 from footprints.mixins import (
-    JSONResponseMixin, LoggedInMixin, EditableMixin, LoggedInStaffMixin)
+    JSONResponseMixin, LoggedInMixin, EditableMixin, ModerationAccessMixin)
 
 
 class IndexView(TemplateView):
@@ -709,7 +709,7 @@ class SignS3View(LoggedInMixin, BaseSignS3View):
         return settings.AWS_STORAGE_BUCKET_NAME
 
 
-class ModerationView(LoggedInStaffMixin, TemplateView):
+class ModerationView(LoggedInMixin, ModerationAccessMixin, TemplateView):
     template_name = 'main/moderation.html'
 
     def get_context_data(self, **kwargs):
@@ -718,7 +718,7 @@ class ModerationView(LoggedInStaffMixin, TemplateView):
         return context
 
 
-class VerifyFootprintView(LoggedInStaffMixin, View):
+class VerifyFootprintView(LoggedInMixin, ModerationAccessMixin, View):
 
     def post(self, *args, **kwargs):
         verified = self.request.POST.get('verified')

--- a/footprints/settings_shared.py
+++ b/footprints/settings_shared.py
@@ -32,7 +32,9 @@ PROJECT_APPS = [
 USE_TZ = True
 
 TEMPLATES[0]['OPTIONS']['context_processors'].append(  # noqa
-    'django.template.context_processors.csrf'
+    'django.template.context_processors.csrf')
+TEMPLATES[0]['OPTIONS']['context_processors'].append(  # noqa
+    'footprints.main.context_processors.permissions'
 )
 
 MIDDLEWARE_CLASSES += [  # noqa

--- a/footprints/templates/base.html
+++ b/footprints/templates/base.html
@@ -61,12 +61,16 @@
                             <li><a href="/search/">Search</a></li>
                         {% endflag %}
                 		<li><a href="http://edblogs.columbia.edu/footprints/" target="_blank">Blog</a></li>
-                        {% if request.user.is_staff %}
+                        {% if can_import or can_moderate %}
                             <li class="dropdown">
                                 <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Manage <span class="caret"></span></a>
                                 <ul class="dropdown-menu">
-                                    <li><a href="/batch/">Batch Import</a></li>
-                                    <li><a href="/moderate/">Moderate</a></li>
+                                    {% if can_import %}
+                                        <li><a href="/batch/">Batch Import</a></li>
+                                    {% endif %}
+                                    {% if can_moderate %}
+                                        <li><a href="/moderate/">Moderate</a></li>
+                                    {% endif %}
                                 </ul>
                             </li>
                         {% endif %}

--- a/footprints/templates/main/footprint_detail.html
+++ b/footprints/templates/main/footprint_detail.html
@@ -79,7 +79,7 @@
                     has_flags: {% if flags %}true{% else %}false{% endif %},
                     work_id: '{{footprint.book_copy.imprint.work.id}}',
                     work_title: '{{footprint.book_copy.imprint.work.title}}',
-                    is_moderator: {% if request.user.is_staff %}true{% else %}false{% endif %}
+                    is_moderator: {% if can_moderate %}true{% else %}false{% endif %}
                 }
             });
 


### PR DESCRIPTION
* Remove 'staff' requirement for moderation and batch import
* Require `batch.*` permission for batch views
   * implemented via BatchAccessMixin
* Require `main.can_moderate` for moderation views
   * implemented via ModerationAccessMixin
* Update the tests to easily construct a user with the needed permissions
* Add a context processor to add in permission levels. Used for navbar construction.
