### PR TITLE
Adjust jQuery context

### DIFF
--- a/footprints/templates/main/footprint_list.html
+++ b/footprints/templates/main/footprint_list.html
@@ -13,7 +13,7 @@
     <script type="text/javascript">
         jQuery(document).ready(function() {
             var view = new FootprintListView({
-                el: jQuery(".object-browse"),
+                el: jQuery(".page"),
                 baseUrl: "{% url 'browse-footprint-list-default' %}",
                 selectedDirection: "{{direction}}",
                 selectedSort: "{{selected_sort}}",


### PR DESCRIPTION
This commit has jQuery select a class that is larger in scope.  This
permits the export button to work outside the classes used for
filtering/searching.