### PR TITLE
Footprint Search Index: add sort fields

### DIFF
--- a/footprints/main/views.py
+++ b/footprints/main/views.py
@@ -172,19 +172,35 @@ class FootprintsSearchView(SearchView):
     template_name = 'main/footprint_advanced_search.html'
     paginate_by = 15
 
+    def get_sort_by(self):
+        sort_by = self.kwargs.get('sort_by', 'ftitle')
+        if sort_by in SORT_OPTIONS.keys():
+            return sort_by
+
+        return 'ftitle'
+
+    def get_direction(self):
+        return self.request.GET.get('direction', 'asc')
+
     def get_queryset(self):
         sqs = super(FootprintsSearchView, self).get_queryset()
         sqs = sqs.exclude(django_ct__in=['main.imprint',
                                          'main.place',
                                          'main.person',
                                          'main.writtenwork'])
-        return sqs.order_by('sort_by')
+
+        sort_by = self.get_sort_by()
+        direction = self.get_direction()
+        if direction == 'desc':
+            sort_by = '-{}'.format(sort_by)
+        print 'sorting by {}'.format(sort_by)
+        return sqs.order_by(sort_by)
 
     def get_context_data(self, **kwargs):
         context = super(FootprintsSearchView, self).get_context_data(**kwargs)
 
-        sort_by = 'ftitle'
-        direction = self.request.GET.get('direction', 'asc')
+        sort_by = self.get_sort_by()
+        direction = self.get_direction()
         query = self.request.GET.get('q', '')
 
         context['selected_sort'] = sort_by

--- a/solr/schema.xml
+++ b/solr/schema.xml
@@ -48,14 +48,6 @@
     <fieldType name="location" class="solr.LatLonType" subFieldSuffix="_coordinate"/>
     <fieldtype name="geohash" class="solr.GeoHashField"/>
 
-    <fieldType name="text_sortable" class="solr.TextField" positionIncrementGap="100">
-      <analyzer>
-        <tokenizer class="solr.KeywordTokenizerFactory"/>
-        <filter class="solr.LowerCaseFilterFactory" />
-        <filter class="solr.TrimFilterFactory" />
-      </analyzer>
-    </fieldType>
-
     <fieldType name="text_general" class="solr.TextField" positionIncrementGap="100">
       <analyzer type="index">
         <tokenizer class="solr.StandardTokenizerFactory"/>

--- a/solr/schema.xml
+++ b/solr/schema.xml
@@ -48,6 +48,14 @@
     <fieldType name="location" class="solr.LatLonType" subFieldSuffix="_coordinate"/>
     <fieldtype name="geohash" class="solr.GeoHashField"/>
 
+    <fieldType name="text_sortable" class="solr.TextField" positionIncrementGap="100">
+      <analyzer>
+        <tokenizer class="solr.KeywordTokenizerFactory"/>
+        <filter class="solr.LowerCaseFilterFactory" />
+        <filter class="solr.TrimFilterFactory" />
+      </analyzer>
+    </fieldType>
+
     <fieldType name="text_general" class="solr.TextField" positionIncrementGap="100">
       <analyzer type="index">
         <tokenizer class="solr.StandardTokenizerFactory"/>
@@ -67,19 +75,9 @@
 
     <fieldType name="text_en" class="solr.TextField" positionIncrementGap="100">
       <analyzer type="index">
-        <tokenizer class="solr.StandardTokenizerFactory"/>
-        <filter class="solr.StopFilterFactory"
-                ignoreCase="true"
-                words="lang/stopwords_en.txt"
-                enablePositionIncrements="true"
-                />
-        <filter class="solr.LowerCaseFilterFactory"/>
-        <filter class="solr.EnglishPossessiveFilterFactory"/>
-        <filter class="solr.KeywordMarkerFilterFactory" protected="protwords.txt"/>
-        <!-- Optionally you may want to use this less aggressive stemmer instead of PorterStemFilterFactory:
-          <filter class="solr.EnglishMinimalStemFilterFactory"/>
-        -->
-        <filter class="solr.PorterStemFilterFactory"/>
+        <tokenizer class="solr.KeywordTokenizerFactory"/>
+        <filter class="solr.LowerCaseFilterFactory" />
+        <filter class="solr.TrimFilterFactory" />
       </analyzer>
       <analyzer type="query">
         <tokenizer class="solr.StandardTokenizerFactory"/>
@@ -151,15 +149,29 @@
     <dynamicField name="*_coordinate"  type="tdouble" indexed="true"  stored="false"/>
 
 
-    <field name="text" type="ngram" indexed="true" stored="true" multiValued="false" />
+    <field name="flocation" type="text_en" indexed="true" stored="true" multiValued="false" />
 
-    <field name="object_type" type="text_en" indexed="true" stored="true" multiValued="false" />
+    <field name="added" type="date" indexed="true" stored="true" multiValued="false" />
+
+    <field name="complete" type="long" indexed="true" stored="true" multiValued="false" />
 
     <field name="title" type="ngram" indexed="true" stored="true" multiValued="false" />
 
+    <field name="text" type="ngram" indexed="true" stored="true" multiValued="false" />
+
+    <field name="ftitle" type="text_en" indexed="true" stored="true" multiValued="false" />
+
+    <field name="object_type" type="text_en" indexed="true" stored="true" multiValued="false" />
+
+    <field name="owners" type="text_en" indexed="true" stored="true" multiValued="false" />
+
     <field name="object_id" type="text_en" indexed="true" stored="true" multiValued="false" />
 
-    <field name="sort_by" type="string" indexed="true" stored="true" multiValued="false" />
+    <field name="sort_by" type="text_en" indexed="true" stored="true" multiValued="false" />
+
+    <field name="fdate" type="date" indexed="true" stored="true" multiValued="false" />
+
+    <field name="wtitle" type="text_en" indexed="true" stored="true" multiValued="false" />
 
     <field name="name" type="ngram" indexed="true" stored="true" multiValued="false" />
 
@@ -174,4 +186,3 @@
   <!-- SolrQueryParser configuration: defaultOperator="AND|OR" -->
   <solrQueryParser defaultOperator="AND"/>
 </schema>
-


### PR DESCRIPTION
* Add a set of Footprint-only sort fields. 
* Redefine base text type to employ minimal tokenization and filtering which interferes with sorts.