### PR TITLE
postgis setup for docker-compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,13 @@
 FROM ccnmtl/django.base
 RUN apt-get update && apt-get install -y \
     build-essential \
+		gdal-bin \
+		libspatialite-dev \
+		libsqlite3-dev \
 		libxml2-dev \
 		libxslt1-dev \
+		python-dev \
+		python-pysqlite2 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,5 @@
 db:
-  image: postgres
+  image: mdillon/postgis
 rabbitmq:
   image: rabbitmq
 web:


### PR DESCRIPTION
This should be easier than setting up a full PostGIS instance locally for development.

This pull request to the base image will need to be merged and pushed first before it will build: https://github.com/ccnmtl/docker/pull/4