### PR TITLE
Remove django-geoposition from requirements

### DIFF
--- a/footprints/main/migrations/0001_initial.py
+++ b/footprints/main/migrations/0001_initial.py
@@ -3,7 +3,6 @@
 from __future__ import unicode_literals
 
 from django.db import models, migrations
-import geoposition.fields
 import audit_log.models.fields
 from django.conf import settings
 
@@ -207,7 +206,7 @@ class Migration(migrations.Migration):
                 ('region', models.CharField(max_length=256, null=True, blank=True)),
                 ('country', models.CharField(max_length=256, null=True, blank=True)),
                 ('city', models.CharField(max_length=256, null=True, blank=True)),
-                ('position', geoposition.fields.GeopositionField(max_length=42, null=True, blank=True)),
+                ('position', models.CharField(max_length=42, null=True, blank=True)),
                 ('notes', models.TextField(null=True, blank=True)),
                 ('created_at', models.DateTimeField(auto_now_add=True)),
                 ('modified_at', models.DateTimeField(auto_now=True)),

--- a/footprints/main/migrations/0003_auto_20150202_1459.py
+++ b/footprints/main/migrations/0003_auto_20150202_1459.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 
 from django.db import migrations
 import datetime
-import geoposition.fields
+from django.db import models
 from django.utils.timezone import utc
 
 
@@ -25,7 +25,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='place',
             name='position',
-            field=geoposition.fields.GeopositionField(
+            field=models.CharField(
                 default=datetime.datetime(2015, 2, 2, 19, 59, 0, 360275,
                                           tzinfo=utc), max_length=42),
             preserve_default=False,

--- a/requirements.txt
+++ b/requirements.txt
@@ -109,7 +109,6 @@ boto==2.46.1
 django-infranil==1.1.0
 pysolr==3.6.0
 django-haystack==2.6.0
-django-geoposition==0.2.2
 django-audit-log==0.7.0
 djangorestframework==3.6.2
 djangorestframework-jsonp==1.0.2


### PR DESCRIPTION
This required the not-so-best-practice of modifying past migrations that referenced the django-geoposition library. Luckily, the field is based on CharField anyway, so it is a fairly innocuous operation.

For a long discussion on trying to remove a field from migrations, see this from the Django project: [Fields referenced in migrations cannot be (re)moved, even if migrations have been squashed](
https://code.djangoproject.com/ticket/23861)