### PR TITLE
ExtendedDate.from_dict - use .get to access elements

### DIFF
--- a/footprints/main/models.py
+++ b/footprints/main/models.py
@@ -79,15 +79,18 @@ class ExtendedDateManager(models.Manager):
 
     def from_dict(self, values):
         dt = self.to_edtf(
-            values['millenium1'], values['century1'], values['decade1'],
-            values['year1'], values['month1'], values['day1'],
-            values['approximate1'], values['uncertain1'])
+            values.get('millenium1'), values.get('century1'),
+            values.get('decade1'),
+            values.get('year1'), values.get('month1'),
+            values.get('day1'),
+            values.get('approximate1'), values.get('uncertain1'))
 
-        if values['is_range']:
+        if values.get('is_range'):
             dt2 = self.to_edtf(
-                values['millenium2'], values['century2'], values['decade2'],
-                values['year2'], values['month2'], values['day2'],
-                values['approximate2'], values['uncertain2'])
+                values.get('millenium2'), values.get('century2'),
+                values.get('decade2'),
+                values.get('year2'), values.get('month2'), values.get('day2'),
+                values.get('approximate2'), values.get('uncertain2'))
 
             dt = '{}/{}'.format(dt, dt2)
 

--- a/footprints/main/tests/test_models.py
+++ b/footprints/main/tests/test_models.py
@@ -214,6 +214,19 @@ class ExtendedDateTest(TestCase):
         dt = ExtendedDate.objects.from_dict(values)
         self.assertEquals(dt.edtf_format, '2001-01-01?~/20xx')
 
+    def test_create_from_dict_missing_elements(self):
+        values = {
+            'is_range': True,
+            'millenium1': 2, 'century1': 0, 'decade1': 0, 'year1': 1,
+            'month1': 1,
+            'approximate1': True, 'uncertain1': True,
+            'millenium2': 2, 'century2': 0, 'decade2': None, 'year2': None,
+            'month2': None, 'day2': None,
+            'approximate2': False, 'uncertain2': False}
+
+        dt = ExtendedDate.objects.from_dict(values)
+        self.assertEquals(dt.edtf_format, '2001-01?~/20xx')
+
     def test_to_edtf(self):
         mgr = ExtendedDate.objects
         dt = mgr.to_edtf(2, None, None, None, None, None, True, True)


### PR DESCRIPTION
Code against the corner-case where date elements are not passed to the server.
I'm not able to reproduce this issue locally, but Sentry shows that,
on occasion, the day1 field goes missing.