### PR TITLE
Footprint verified_modified_at: set using timezone aware syntax

### DIFF
--- a/footprints/main/models.py
+++ b/footprints/main/models.py
@@ -1,12 +1,13 @@
-from datetime import date, datetime
+from datetime import date
 
 from audit_log.models.fields import LastUserField, CreatingUserField
 from django.contrib.gis.db.models.fields import PointField
 from django.db import models
 from django.template import loader
+from django.utils import timezone
 from edtf import EDTF, edtf_date
 
-from footprints.main.templatetags.moderation import has_moderation_flags,\
+from footprints.main.templatetags.moderation import has_moderation_flags, \
     moderation_flags
 from footprints.main.utils import string_to_point
 
@@ -1066,7 +1067,7 @@ class Footprint(models.Model):
 
     def save_verified(self, verified):
         self.verified = verified
-        self.verified_modified_at = datetime.now()
+        self.verified_modified_at = timezone.now()
         self.save(update_fields=['verified', 'verified_modified_at'])
 
     def flags(self):

--- a/footprints/main/tests/test_models.py
+++ b/footprints/main/tests/test_models.py
@@ -1,8 +1,7 @@
-import datetime
-
 from django.contrib.auth.models import Group
 from django.db.utils import IntegrityError
 from django.test import TestCase
+from django.utils import timezone
 
 from footprints.main.models import Language, DigitalFormat, \
     ExtendedDate, StandardizedIdentification, \
@@ -492,7 +491,7 @@ class FootprintModerationTest(TestCase):
         self.assertTrue(moderation_flags(f3))
 
         # excluded footprints
-        today = datetime.datetime.now()
+        today = timezone.now()
         f4 = FootprintFactory()
         f4.save_verified(True)
         self.assertTrue(moderation_flags(f4))


### PR DESCRIPTION
removes warnings