### PR TITLE
Batch imprint integrity: only require written work title match

### DIFF
--- a/footprints/batch/models.py
+++ b/footprints/batch/models.py
@@ -181,31 +181,15 @@ class BatchRow(models.Model):
 
         imprints = Imprint.objects.filter(
             standardized_identifier__identifier=self.bhb_number)
-        imprint = imprints.select_related(
-            'place', 'publication_date', 'work').first()
+        imprint = imprints.select_related('work').first()
 
         if imprint is None:
             return msg
 
-        fields = []
-
-        # title, date, location & writtenwork title should match
-        if imprint.title != self.imprint_title:
-            fields.append('title')
-
-        if (imprint.publication_date and
-            not imprint.publication_date.match_string(
-                self.publication_date)):
-            fields.append('publication date')
-
-        if not imprint.place.match_string(self.publication_location):
-            fields.append('publication location')
-
+        # writtenwork title must match
         if (self.writtenwork_title and
                 imprint.work.title.lower() != self.writtenwork_title.lower()):
-            fields.append('literary work title')
-
-        if len(fields):
+            fields = ['literary work title']
             msg = self.IMPRINT_INTEGRITY.format(
                 imprint.work.id, imprint.id, ', '.join(fields))
 

--- a/footprints/batch/tests/test_models.py
+++ b/footprints/batch/tests/test_models.py
@@ -1,7 +1,6 @@
 from django.test.testcases import TestCase
 
 from footprints.batch.tests.factories import BatchRowFactory
-from footprints.main.models import ExtendedDate, Place
 from footprints.main.tests.factories import ImprintFactory, BookCopyFactory, \
     FootprintFactory, WrittenWorkFactory, StandardizedIdentificationFactory, \
     ActorFactory
@@ -67,8 +66,7 @@ class BatchRowTest(TestCase):
         sid = StandardizedIdentificationFactory(identifier=row.bhb_number)
         imprint.standardized_identifier.add(sid)
 
-        flds = ['title', 'publication date',
-                'publication location', 'literary work title']
+        flds = ['literary work title']
         self.assertTrue(', '.join(flds) in row.check_imprint_integrity())
 
         # found imprint, fields match
@@ -77,11 +75,6 @@ class BatchRowTest(TestCase):
 
         sid = StandardizedIdentificationFactory(identifier=row.bhb_number)
         imprint.standardized_identifier.add(sid)
-
-        imprint.publication_date = ExtendedDate.objects.create(
-            edtf_format=row.publication_date)
-        imprint.place, created = Place.objects.get_or_create_from_string(coord)
-        imprint.save()
 
         self.assertIsNone(row.check_imprint_integrity())
 


### PR DESCRIPTION
Remove checks around imprint title, publication date & location