### PR TITLE
Imprint & Footprint End Dates: Return max for a given range

### DIFF
--- a/footprints/main/models.py
+++ b/footprints/main/models.py
@@ -227,9 +227,9 @@ class ExtendedDate(models.Model):
         edtf = self.as_edtf()
 
         if not edtf.is_interval:
-            return None
+            return edtf.date_latest()
 
-        return self._validate_python_date(edtf.end_date_earliest())
+        return self._validate_python_date(edtf.end_date_latest())
 
     def match_string(self, date_str):
         return self.edtf_format == unicode(EDTF.from_natural_text(date_str))

--- a/footprints/main/search_indexes.py
+++ b/footprints/main/search_indexes.py
@@ -107,14 +107,14 @@ class FootprintIndex(CelerySearchIndex, Indexable):
         return obj.sort_date()
 
     def prepare_footprint_end_date(self, obj):
-        return obj.end_date() or obj.start_date()
+        return obj.end_date()
 
     def prepare_footprint_start_date(self, obj):
         return obj.start_date()
 
     def prepare_pub_end_date(self, obj):
         imprint = obj.book_copy.imprint
-        return imprint.end_date() or imprint.start_date()
+        return imprint.end_date()
 
     def prepare_pub_start_date(self, obj):
         imprint = obj.book_copy.imprint

--- a/footprints/main/tests/test_models.py
+++ b/footprints/main/tests/test_models.py
@@ -2,6 +2,7 @@ from django.contrib.auth.models import Group
 from django.db.utils import IntegrityError
 from django.test import TestCase
 from django.utils import timezone
+import datetime
 
 from footprints.main.models import Language, DigitalFormat, \
     ExtendedDate, StandardizedIdentification, \
@@ -260,6 +261,19 @@ class ExtendedDateTest(TestCase):
     def test_invalid_month(self):
         dt = ExtendedDate.objects.create(edtf_format='uuuu-uu-17/uuuu-uu-18')
         self.assertEquals(dt.__unicode__(), ' 17, uuuu -  18, uuuu')
+
+    def test_end_date(self):
+        dt = ExtendedDate.objects.create(edtf_format='1700')
+        self.assertEquals(dt.end(), datetime.date(1700, 12, 31))
+
+        dt = ExtendedDate.objects.create(edtf_format='1700/open')
+        self.assertIsNone(dt.end())
+
+        dt = ExtendedDate.objects.create(edtf_format='1700/unknown')
+        self.assertEquals(dt.end(), datetime.date(1705, 12, 31))
+
+        dt = ExtendedDate.objects.create(edtf_format='1700/18xx')
+        self.assertEquals(dt.end(), datetime.date(1899, 12, 31))
 
 
 class ImprintTest(TestCase):


### PR DESCRIPTION
Tweaking the way the Footprint end_date and Imprint publication_end_date are specified to the SOLR search engine. In general, we want to make sure the end date is at the maximum end of a given range.

For example:
* An ExtendedDateTime of 1700 should specify a range of 1700-01-01 to 1700-12-31.
* An ExtendedDateTime of 1700 - present should specify a range of 1700-01-01 with an empty end date.
* An ExtendedDateTime of 1700 - 18xx should specify  a range of 1700-01-01 to 1899-12-31.

Previously, the end date was sometimes incorrectly specified as the start date or the earliest end date.