### PR TITLE
Add indexed field: has_image

### DIFF
--- a/footprints/main/forms.py
+++ b/footprints/main/forms.py
@@ -122,7 +122,12 @@ class FootprintSearchForm(ModelSearchForm):
             'django_ct': 'main.footprint',
         }
 
-        q = self.cleaned_data.get('q')
+        q = self.cleaned_data.get('q', '')
+
+        if q.find('has:image') > -1:
+            args.append(Q(has_image=True))
+            q = q.replace('has:image', '')
+
         if q:
             kwargs['content'] = q
 

--- a/footprints/main/search_indexes.py
+++ b/footprints/main/search_indexes.py
@@ -5,7 +5,7 @@ from django.db.models.query_utils import Q
 from django.utils.encoding import smart_text
 from haystack.constants import Indexable
 from haystack.fields import CharField, NgramField, DateTimeField, \
-    IntegerField, MultiValueField
+    IntegerField, MultiValueField, BooleanField
 from unidecode import unidecode
 
 from footprints.main.models import WrittenWork, Footprint, Person, Place, \
@@ -72,6 +72,8 @@ class FootprintIndex(CelerySearchIndex, Indexable):
     imprint_location = CharField(faceted=True)
 
     actor = MultiValueField(faceted=True)
+
+    has_image = BooleanField()
 
     # custom sort fields
     added = DateTimeField(model_attr='created_at')
@@ -150,6 +152,9 @@ class FootprintIndex(CelerySearchIndex, Indexable):
             Q(footprint=obj)).distinct()
 
         return [smart_text(actor) for actor in qs]
+
+    def prepare_has_image(self, obj):
+        return obj.has_at_least_one_digital_object()
 
 
 class PersonIndex(CelerySearchIndex, Indexable):

--- a/solr/schema.solr7.xml
+++ b/solr/schema.solr7.xml
@@ -157,6 +157,8 @@
 
     <field name="footprint_location_exact" type="string" indexed="true" stored="true" multiValued="false" />
 
+    <field name="has_image" type="boolean" indexed="true" stored="true" multiValued="false" />
+
     <field name="footprint_start_date" type="date" indexed="true" stored="true" multiValued="false" />
 
     <field name="text" type="ngram" indexed="true" stored="true" multiValued="false" />

--- a/solr/schema.xml
+++ b/solr/schema.xml
@@ -149,6 +149,8 @@
 
     <field name="footprint_location_exact" type="string" indexed="true" stored="true" multiValued="false" />
 
+    <field name="has_image" type="boolean" indexed="true" stored="true" stored="true" multiValued="false" />
+
     <field name="footprint_start_date" type="date" indexed="true" stored="true" multiValued="false" />
 
     <field name="text" type="ngram" indexed="true" stored="true" multiValued="false" />


### PR DESCRIPTION
This PR adds an advanced search syntax `has:image` to the Footprints search. 

Update: this can now be merged. solr configuration has been modified.

