### PR TITLE
Add BookCopy search index

### DIFF
--- a/footprints/main/models.py
+++ b/footprints/main/models.py
@@ -1010,6 +1010,28 @@ class BookCopy(models.Model):
         lst.sort(key=lambda obj: obj.sort_date())
         return lst
 
+    def footprints_with_valid_dates(self):
+        return self.footprint_set.filter(
+            associated_date__isnull=False).exclude(
+                associated_date__edtf_format__exact='').select_related(
+                    'associated_date')
+
+    def footprints_start_date(self):
+        try:
+            lst = list(self.footprints_with_valid_dates())
+            lst.sort(key=lambda obj: obj.start_date())
+            return lst[0].start_date()
+        except IndexError:
+            None
+
+    def footprints_end_date(self):
+        try:
+            lst = list(self.footprints_with_valid_dates())
+            lst.sort(key=lambda obj: obj.end_date())
+            return lst[-1].end_date()
+        except IndexError:
+            return None
+
 
 @python_2_unicode_compatible
 class Footprint(models.Model):

--- a/footprints/main/tests/test_models.py
+++ b/footprints/main/tests/test_models.py
@@ -177,6 +177,28 @@ class BookCopyTest(TestCase):
         self.assertEquals(current_owners.count(), 1)
         self.assertIsNotNone(current_owners.get(id=owner2.id))
 
+    def test_book_copy_dates(self):
+        copy = BookCopyFactory()
+
+        EmptyFootprintFactory(book_copy=copy)
+        FootprintFactory(
+            book_copy=copy,
+            associated_date=ExtendedDateFactory(edtf_format=''))
+        FootprintFactory(
+            book_copy=copy,
+            associated_date=ExtendedDateFactory(edtf_format='1981/2000'))
+        FootprintFactory(
+            book_copy=copy,
+            associated_date=ExtendedDateFactory(edtf_format='1982'))
+        FootprintFactory(
+            book_copy=copy,
+            associated_date=ExtendedDateFactory(edtf_format='1983'))
+
+        self.assertEqual(
+            copy.footprints_start_date(), datetime.date(1981, 1, 1))
+        self.assertEqual(
+            copy.footprints_end_date(), datetime.date(2000, 12, 31))
+
 
 class ExtendedDateTest(TestCase):
 

--- a/footprints/main/tests/test_search_indexes.py
+++ b/footprints/main/tests/test_search_indexes.py
@@ -1,7 +1,7 @@
 from django.test.testcases import TestCase
 from django.utils.encoding import smart_text
 
-from footprints.main.search_indexes import FootprintIndex
+from footprints.main.search_indexes import FootprintIndex, BookCopyIndex
 from footprints.main.tests.factories import FootprintFactory
 
 
@@ -11,6 +11,16 @@ class TestFootprintIndex(TestCase):
         fp = FootprintFactory()
 
         actors = FootprintIndex().prepare_actor(fp)
+        self.assertTrue(smart_text(fp.actor.first()) in actors)
+        self.assertTrue(smart_text(fp.book_copy.imprint.work.actor.first())
+                        in actors)
+
+
+class TestBookCopyIndex(TestCase):
+    def test_prepare_actor(self):
+        fp = FootprintFactory()
+
+        actors = BookCopyIndex().prepare_actor(fp.book_copy)
         self.assertTrue(smart_text(fp.actor.first()) in actors)
         self.assertTrue(smart_text(fp.book_copy.imprint.work.actor.first())
                         in actors)

--- a/footprints/templates/base.html
+++ b/footprints/templates/base.html
@@ -14,7 +14,7 @@
         {% block seosettings %}
         <meta name="robots" content="noindex">
         {% endblock %}
-        
+
         <!-- Bootstrap CSS: -->
         <link href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css" rel="stylesheet">
         {% compress css %}

--- a/footprints/templates/search/indexes/main/bookcopy_text.txt
+++ b/footprints/templates/search/indexes/main/bookcopy_text.txt
@@ -1,0 +1,2 @@
+{{object.imprint.title}}
+{{object.imprint.work.title}}

--- a/footprints/templates/search/search.html
+++ b/footprints/templates/search/search.html
@@ -6,11 +6,11 @@
 <div class="page-header">
   <h1>Search</h1>
 </div>
-            
+
 <div class="object-search">
     <div class="row">
         <div class="col-md-3">
-        
+
             <form method="get" action=".">
                 <br />
                 <div class="form-group">

--- a/solr/schema.xml
+++ b/solr/schema.xml
@@ -189,6 +189,9 @@
 
     <field name="name" type="ngram" indexed="true" stored="true" multiValued="false" />
 
+    <field name="footprint_locations" type="text_en" indexed="true" stored="true" multiValued="true" />
+
+    <field name="footprint_locations_exact" type="string" indexed="true" stored="true" multiValued="true" />
   </fields>
 
   <!-- field to use to determine and enforce document uniqueness. -->


### PR DESCRIPTION
The Footprints Pathmapper visualization requires a search for book copies rather than footprints. To support this requirement, this PR adds a BookCopy object to the Solr index, allowing faster, faceted and aggregated search interfaces.

Note: This update will require deploying a new schema.xml out to the Solr instance. Please coordinate with me before merging this PR.