### PR TITLE
Pathmapper: add Place search_title

### DIFF
--- a/footprints/main/models.py
+++ b/footprints/main/models.py
@@ -657,6 +657,15 @@ class Place(models.Model):
 
         return ', '.join(parts)
 
+    def search_title(self):
+        parts = []
+        if self.country:
+            parts.append(self.country)
+        if self.city:
+            parts.append(self.city)
+
+        return ': '.join(parts)
+
     def latitude(self):
         return self.latlng.coords[1]
 

--- a/footprints/main/serializers.py
+++ b/footprints/main/serializers.py
@@ -96,12 +96,13 @@ class PersonSerializer(HyperlinkedModelSerializer):
 
 class PlaceSerializer(HyperlinkedModelSerializer):
     display_title = ReadOnlyField()
+    search_title = ReadOnlyField()
     latitude = ReadOnlyField()
     longitude = ReadOnlyField()
 
     class Meta:
         model = Place
-        fields = ('id', 'display_title', 'country', 'city',
+        fields = ('id', 'display_title', 'search_title', 'country', 'city',
                   'latitude', 'longitude')
 
 

--- a/footprints/main/tests/test_models.py
+++ b/footprints/main/tests/test_models.py
@@ -89,6 +89,16 @@ class PersonTest(TestCase):
 
 
 class PlaceTest(TestCase):
+
+    def test_titles(self):
+        p = PlaceFactory()
+        self.assertEquals(p.display_title(), 'Cracow, Poland')
+        self.assertEquals(p.search_title(), 'Poland: Cracow')
+
+        p = Place(country='Poland')
+        self.assertEquals(p.display_title(), 'Poland')
+        self.assertEquals(p.search_title(), 'Poland')
+
     def test_place(self):
         latlng = '50.06465,19.944979'
         pt = string_to_point(latlng)

--- a/media/js/app/components/select-widget.js
+++ b/media/js/app/components/select-widget.js
@@ -47,8 +47,10 @@ define(['jquery', 'select2'], function($, select2) {
                     delay: 250,
                     processResults: function(data, params) {
                         let results = $.map(data.results, function(obj) {
-                            obj.text = obj.title || obj.display_title;
-                            obj.html = obj.description || obj.display_title;
+                            obj.text = obj.title || obj.search_title ||
+                                obj.display_title;
+                            obj.html = obj.description || obj.search_title ||
+                                obj.display_title;
                             return obj;
                         });
 


### PR DESCRIPTION
Scanning a list of traditional Place display names `city, country` was proving difficult. Swap out for a `country: city` format.