### PR TITLE
Configure postgres testing for Travis CI only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,15 +7,11 @@ python:
   - "3.6"
 before_install:
   - sudo apt-get install --yes postgresql-9.6-postgis-2.4
-install:
-  - pip install -U pip wheel
-  - pip install -U setuptools
-  - pip install -r requirements.txt
 before_script:
   - psql -c 'create database test_footprints;' -U postgres
   - psql -U postgres -c 'CREATE EXTENSION postgis;' -d test_footprints
 script:
-  - make
+  - make travis
 notifications:
   slack: ccnmtl:GizSNscLWJLldjQrffB8mwgm
 addons:

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ all: jenkins
 include *.mk
 
 test-travis: $(PY_SENTINAL)
-    $(MANAGE) jenkins --pep8-exclude=migrations --enable-coverage --coverage-rcfile=.coveragerc --settings=$(APP).settings_travis
+	$(MANAGE) jenkins --pep8-exclude=migrations --enable-coverage --coverage-rcfile=.coveragerc --settings=$(APP).settings_travis
 
 travis: check flake8 test-travis eslint bandit
 

--- a/Makefile
+++ b/Makefile
@@ -8,3 +8,9 @@ all: jenkins
 
 include *.mk
 
+test-travis: $(PY_SENTINAL)
+    $(MANAGE) jenkins --pep8-exclude=migrations --enable-coverage --coverage-rcfile=.coveragerc --settings=$(APP).settings_travis
+
+travis: check flake8 test-travis eslint bandit
+
+

--- a/footprints/main/migrations/0001_initial.py
+++ b/footprints/main/migrations/0001_initial.py
@@ -96,7 +96,7 @@ class Migration(migrations.Migration):
             bases=(models.Model,),
         ),
         migrations.CreateModel(
-            name='ExtendedDateFormat',
+            name='ExtendedDate',
             fields=[
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('edtf_format', models.CharField(max_length=256)),
@@ -120,7 +120,7 @@ class Migration(migrations.Migration):
                 ('created_at', models.DateTimeField(auto_now_add=True)),
                 ('modified_at', models.DateTimeField(auto_now=True)),
                 ('actor', models.ManyToManyField(help_text=b'An owner or other person related to this footprint. ', to='main.Actor', null=True, blank=True)),
-                ('associated_date', models.OneToOneField(null=True, blank=True, to='main.ExtendedDateFormat', verbose_name=b'Footprint Date', on_delete=models.CASCADE)),
+                ('associated_date', models.OneToOneField(null=True, blank=True, to='main.ExtendedDate', verbose_name=b'Footprint Date', on_delete=models.CASCADE)),
                 ('book_copy', models.ForeignKey(blank=True, to='main.BookCopy', null=True, on_delete=models.CASCADE)),
                 ('collection', models.ForeignKey(blank=True, to='main.Collection', null=True, on_delete=models.CASCADE)),
                 ('created_by', audit_log.models.fields.CreatingUserField(related_name='footprint_created_by', editable=False, to=settings.AUTH_USER_MODEL, null=True)),
@@ -142,7 +142,7 @@ class Migration(migrations.Migration):
                 ('modified_at', models.DateTimeField(auto_now=True)),
                 ('actor', models.ManyToManyField(to='main.Actor', null=True, blank=True)),
                 ('created_by', audit_log.models.fields.CreatingUserField(related_name='imprint_created_by', editable=False, to=settings.AUTH_USER_MODEL, null=True)),
-                ('date_of_publication', models.OneToOneField(null=True, blank=True, to='main.ExtendedDateFormat', on_delete=models.CASCADE)),
+                ('date_of_publication', models.OneToOneField(null=True, blank=True, to='main.ExtendedDate', on_delete=models.CASCADE)),
                 ('digital_object', models.ManyToManyField(to='main.DigitalObject', null=True, blank=True)),
             ],
             options={
@@ -186,9 +186,9 @@ class Migration(migrations.Migration):
                 ('notes', models.TextField(null=True, blank=True)),
                 ('created_at', models.DateTimeField(auto_now_add=True)),
                 ('modified_at', models.DateTimeField(auto_now=True)),
-                ('birth_date', models.OneToOneField(related_name='birth_date', null=True, blank=True, to='main.ExtendedDateFormat', on_delete=models.CASCADE)),
+                ('birth_date', models.OneToOneField(related_name='birth_date', null=True, blank=True, to='main.ExtendedDate', on_delete=models.CASCADE)),
                 ('created_by', audit_log.models.fields.CreatingUserField(related_name='person_created_by', editable=False, to=settings.AUTH_USER_MODEL, null=True)),
-                ('death_date', models.OneToOneField(related_name='death_date', null=True, blank=True, to='main.ExtendedDateFormat', on_delete=models.CASCADE)),
+                ('death_date', models.OneToOneField(related_name='death_date', null=True, blank=True, to='main.ExtendedDate', on_delete=models.CASCADE)),
                 ('digital_object', models.ManyToManyField(to='main.DigitalObject', null=True, blank=True)),
                 ('last_modified_by', audit_log.models.fields.LastUserField(related_name='person_last_modified_by', editable=False, to=settings.AUTH_USER_MODEL, null=True)),
             ],

--- a/footprints/main/migrations/0019_auto_20151204_0942.py
+++ b/footprints/main/migrations/0019_auto_20151204_0942.py
@@ -10,8 +10,4 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RenameModel(
-            old_name='ExtendedDateFormat',
-            new_name='ExtendedDate',
-        ),
     ]

--- a/footprints/settings_shared.py
+++ b/footprints/settings_shared.py
@@ -48,11 +48,11 @@ if ('test' in sys.argv or 'jenkins' in sys.argv or 'validate' in sys.argv
         or 'check' in sys.argv):
     DATABASES = {
         'default': {
-            'ENGINE': 'django.contrib.gis.db.backends.postgis',
-            'NAME': 'test_footprints',
+            'ENGINE': 'django.contrib.gis.db.backends.spatialite',
+            'NAME': ':memory:',
             'HOST': '',
             'PORT': '',
-            'USER': 'postgres',
+            'USER': '',
             'PASSWORD': '',
             'ATOMIC_REQUESTS': True,
         }

--- a/footprints/settings_travis.py
+++ b/footprints/settings_travis.py
@@ -1,0 +1,15 @@
+import sys
+
+if ('test' in sys.argv or 'jenkins' in sys.argv or 'validate' in sys.argv
+        or 'check' in sys.argv):
+    DATABASES = {
+        'default': {
+            'ENGINE': 'django.contrib.gis.db.backends.postgis',
+            'NAME': 'test_footprints',
+            'HOST': '',
+            'PORT': '',
+            'USER': 'postgres',
+            'PASSWORD': '',
+            'ATOMIC_REQUESTS': True,
+        }
+    }

--- a/footprints/settings_travis.py
+++ b/footprints/settings_travis.py
@@ -1,4 +1,13 @@
+# flake8: noqa
 import sys
+from footprints.settings_shared import *
+
+
+try:
+    from footprints.local_settings import *
+except ImportError:
+    pass
+
 
 if ('test' in sys.argv or 'jenkins' in sys.argv or 'validate' in sys.argv
         or 'check' in sys.argv):


### PR DESCRIPTION
This PR removes the problematic table rename migration that crashes sqlite3 and adds configuration to keep Postgres testing on Travis and Sqlite3 testing on our CI server.

The sqlite3 rename issue seem to be related to this issue: https://code.djangoproject.com/ticket/29182#no1. Note that it is inherently evil to rewrite a migration...however, the migration happened years ago and I believe it will have no impact on production.

Though this fix resolves the build locally and on the CI server, Travis now reports a segmentation fault when running the unit tests. (A segfault is also a known issue with sqlite3 :memory: databases with lots of tests. Example: https://github.com/pytest-dev/pytest-django/issues/409). In order to get things moving, I'm leaving Travis to test on postgres.

 