### PR TITLE
Pathmapper: add route view

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -21,7 +21,8 @@ module.exports = {
         "Backbone": true,
         "google": true,
         "Footprints": true,
-        "requirejs": true
+        "requirejs": true,
+        "Promise": true
     },
     "rules": {
         "indent": [

--- a/footprints/main/serializers.py
+++ b/footprints/main/serializers.py
@@ -220,26 +220,10 @@ class FootprintSerializer(HyperlinkedModelSerializer):
         return smart_text(obj.book_copy.identifier())
 
 
-class WrittenWorkPathSerializer(HyperlinkedModelSerializer):
-    class Meta:
-        model = WrittenWork
-        fields = ('id', 'title')
-
-
-class ImprintPathSerializer(HyperlinkedModelSerializer):
-    work = WrittenWorkPathSerializer()
-    place = PlaceSerializer()
-    publication_date = ExtendedDateSerializer()
+class BookCopyRouteSerializer(HyperlinkedModelSerializer):
+    imprint = ImprintSerializer(read_only=True)
+    footprints = FootprintSerializer(many=True, read_only=True)
 
     class Meta:
-        model = Imprint
-        fields = ('id', 'work', 'title', 'place', 'publication_date')
-
-
-class FootprintPathSerializer(HyperlinkedModelSerializer):
-    associated_date = ExtendedDateSerializer()
-    place = PlaceSerializer()
-
-    class Meta:
-        model = Footprint
-        fields = ('id', 'title', 'associated_date', 'place', 'sort_date')
+        model = BookCopy
+        fields = ('id', 'imprint', 'footprints')

--- a/footprints/pathmapper/tests/test_views.py
+++ b/footprints/pathmapper/tests/test_views.py
@@ -27,3 +27,17 @@ class PathmapperTableViewTest(TestCase):
         self.assertEqual(the_json['next'], None)
         self.assertEqual(the_json['previous'], None)
         self.assertEqual(the_json['results'], [])
+
+
+class PathmapperRouteViewTest(TestCase):
+
+    def test_post(self):
+        url = reverse('pathmapper-route-view')
+        response = self.client.post(url, {'layer': '{}'},
+                                    HTTP_X_REQUESTED_WITH='XMLHttpRequest')
+        self.assertEqual(response.status_code, 200)
+        the_json = loads(response.content.decode('utf-8'))
+        self.assertEqual(the_json['count'], 0)
+        self.assertEqual(the_json['next'], None)
+        self.assertEqual(the_json['previous'], None)
+        self.assertEqual(the_json['results'], [])

--- a/footprints/urls.py
+++ b/footprints/urls.py
@@ -27,7 +27,8 @@ from footprints.main.viewsets import (
     StandardizedIdentificationViewSet, DigitalFormatViewSet,
     DigitalObjectViewSet, StandardizedIdentificationTypeViewSet)
 from footprints.pathmapper.views import (
-    PathmapperView, BookCopySearchView, PathmapperTableView)
+    PathmapperView, BookCopySearchView, PathmapperTableView,
+    PathmapperRouteView)
 
 
 admin.autodiscover()
@@ -168,6 +169,8 @@ urlpatterns = [
 
     url(r'^pathmapper/table/',
         PathmapperTableView.as_view(), name='pathmapper-table-view'),
+    url(r'^pathmapper/route/',
+        PathmapperRouteView.as_view(), name='pathmapper-route-view'),
 
     # Visualizations for grant application
     url(r'^pathmapper/',

--- a/media/js/app/common.js
+++ b/media/js/app/common.js
@@ -12,9 +12,9 @@ requirejs.config({
         'layerListVue': 'js/app/components/layerlistvue',
         'layerVue': 'js/app/components/layervue',
         'mapVue': 'js/app/components/mapvue',
-        'tableVue': 'js/app/components/tableVue',
         'select2': 'js/lib/select2-4.0.10/js/select2.full',
         'selectWidget': 'js/app/components/select-widget',
+        'tableVue': 'js/app/components/tableVue',
         'utils': 'js/app/utils',
         'Vue': vuePath
     },

--- a/media/js/app/components/mapvue.js
+++ b/media/js/app/components/mapvue.js
@@ -1,23 +1,53 @@
-define(['jquery'], function($) {
+define(['jquery', 'utils'], function($, utils) {
     const GoogleMapVue = {
         props: ['value'],
         template: '#google-map-template',
         data: function() {
             return {
-                mapName: 'the-map'
+                mapName: 'the-map',
+                routes: []
             };
         },
         methods: {
-            updateLayers: function() {
-                // @todo - for each layer, query book copy routes
-                console.log('update map');
+            url: function(pageNumber) {
+                return Footprints.baseUrl +
+                    'pathmapper/route/?page=' + pageNumber;
+            },
+            mapData: function(data) {
+                // @todo - map the data here.
+                console.log(data);
+            },
+            getData: function(params) {
+                const ctx = {
+                    layer: JSON.stringify(params.layer)
+                };
+                return new Promise((resolve, reject) => {
+                    $.ajax({
+                        type: 'POST',
+                        url: this.url(params.page),
+                        dataType: 'json',
+                        data: ctx,
+                        success: (data) => {
+                            resolve(data);
+                        },
+                        error: (error) => {
+                            reject(error);
+                        }
+                    });
+                });
+            },
+            updateRoutes: function() {
+                for (let layer of this.value) {
+                    const ctx = {'layer': layer, 'page': 1};
+                    this.q.add(this.getData, this.mapData, ctx);
+                }
             }
         },
         created: function() {
+            this.q = new utils.AsyncQueue();
             this.bounds = null;
             this.zoom = 5;
             this.center = new google.maps.LatLng(37.0902, -95.7129);
-            this.$watch('value', this.updateLayers, {deep: true});
         },
         mounted: function() {
             let elt = document.getElementById(this.mapName);
@@ -31,6 +61,7 @@ define(['jquery'], function($) {
                     position: google.maps.ControlPosition.RIGHT_BOTTOM,
                 }
             });
+            this.updateRoutes();
         }
     };
     return {

--- a/media/js/app/components/tableVue.js
+++ b/media/js/app/components/tableVue.js
@@ -19,13 +19,14 @@ define(['jquery', 'utils'], function($, layer, utils) {
                 return this.page.prevPage;
             },
             parsePageNumber: function(str) {
-                if (str && str.length > 0) {
+                let pageNumber = 1;
+                try {
                     let result = str.matchAll(/page=(\d+)/);
-                    if (result) {
-                        return parseInt(result.next().value[1], 10);
-                    }
+                    pageNumber = parseInt(result.next().value[1], 10);
+                } catch (err) {
+                    // continue with default page number
                 }
-                return 1;
+                return pageNumber;
             },
             changePage: function(pg) {
                 this.page.number = pg;

--- a/media/js/app/utils.js
+++ b/media/js/app/utils.js
@@ -1,4 +1,23 @@
 define(function() {
+    // Simplifying this approach
+    // https://stackoverflow.com/questions/50498666/nodejs-async-promise-queue
+    class AsyncQueue {
+        constructor() {
+            this.queue = [];
+            // eslint-disable-next-line scanjs-rules/call_setInterval
+            setInterval(this.resolveNext.bind(this), 100);
+        }
+        add(fn, cb, params) {
+            this.queue.push({fn, cb, params});
+        }
+        resolveNext() {
+            if (!this.queue.length) {
+                return;
+            }
+            const {fn, cb, params} = this.queue.shift();
+            fn(params).then(cb);
+        }
+    }
 
     function csrfSafeMethod(method) {
         // these HTTP methods do not require CSRF protection
@@ -60,6 +79,7 @@ define(function() {
     }
 
     return {
+        AsyncQueue: AsyncQueue,
         ajaxSetup: ajaxSetup,
         csrfSafeMethod: csrfSafeMethod,
         sanitize: sanitize,


### PR DESCRIPTION
This PR adds:
* PathmapperRouteView that given layer criteria, retrieves book copies and returns the serialized data for associated imprint and footprints in a paginated response. (Going forward, the serializer might be optimized to simply return the list of places that will be mapped.)
* Clientside MapVue that requests the route data. An asynchronous queue is used to tee up requests, with the hope that this approach will be reasonably efficient. Still to do -- add "next page" requests as the initial page data is retrieved, and put the route on the map.