### PR TITLE
Pathmapper: Read / Write Share Url

### DIFF
--- a/footprints/main/utils.py
+++ b/footprints/main/utils.py
@@ -82,8 +82,8 @@ class BrowsableAPIRendererNoForms(BrowsableAPIRenderer):
         return ""
 
 
-def string_to_point(str):
-    a = str.split(',')
+def string_to_point(s):
+    a = s.split(',')
     return Point(float(a[1].strip()), float(a[0].strip()))
 
 

--- a/footprints/templates/base-new.html
+++ b/footprints/templates/base-new.html
@@ -216,7 +216,7 @@
             staticUrl: '{{STATIC_URL}}',
             debug: {% if debug %}'true'{% else %}'false'{% endif %},
             mapKey: '{{settings.GOOGLE_MAP_API}}',
-            baseUrl: '//{{ request.get_host }}/'
+            baseUrl: '{{request.scheme}}://{{ request.get_host }}/'
         };
 
         jQuery(document).ready(function() {

--- a/footprints/templates/clientside/layer_form_template.html
+++ b/footprints/templates/clientside/layer_form_template.html
@@ -3,10 +3,10 @@
     <div class="pane-content" id="create-layer-init">
         <header class="d-flex flex-row">
             <h1><i class="fas fa-layer-group mr-2" aria-hidden="true"></i>
-                <span v-if="layer.id !== null">Edit Layer</span>
+                <span v-if="layer.layerId !== null">Edit Layer</span>
                 <span v-else>New layer</span>
             </h1>
-            <label v-if="layer.id !== null" for="layerTitle" class="sr-only">Edit layer title</label>
+            <label v-if="layer.layerId !== null" for="layerTitle" class="sr-only">Edit layer title</label>
             <label v-else for="layerTitle" class="sr-only">New layer title</label>
             <input type="text" class="form-control criteria-form-field" id="layerTitle" v-model="layer.title">
         </header>
@@ -152,7 +152,7 @@
 
             <div class="layer-actions">
                 <button v-on:click="cancel" type="button" class="btn btn-priority-low">Cancel</button>
-                <button v-if="layer.id !== null" v-on:click="save" type="button" class="btn btn-priority-mid">Save layer</button>
+                <button v-if="layer.layerId !== null" v-on:click="save" type="button" class="btn btn-priority-mid">Save layer</button>
                 <button v-else v-on:click="save" type="button" class="btn btn-priority-mid">Create layer</button>
             </div><!-- /.layer actions -->
 

--- a/footprints/templates/pathmapper/map.html
+++ b/footprints/templates/pathmapper/map.html
@@ -41,8 +41,8 @@
                     <h2>Share results</h2>
                 </div><!-- /.share-panel-header -->
                 <div class="share-panel-copylink form-group">
-                            <label for="shareCopyLink">Link to share:</label>
-                            <input type="text" class="form-control" id="shareCopyLink" value="pathmapperly link">
+                    <label for="shareCopyLink">Link to share:</label>
+                    <input type="text" class="form-control" id="shareCopyLink" :value="shareUrl">
                 </div><!-- /.share-panel-copylink -->
                 <div class="share-panel-socmedia d-flex justify-content-center">
                     <button class="share-panel-facebook" value="Facebook">
@@ -77,6 +77,8 @@
 {% endblock %}
 
 {% block js %}
+    {{ layers|json_script:"layers" }}
+
     <script type="text/javascript"
         src="//maps.google.com/maps/api/js?key={{settings.GOOGLE_MAP_API}}&libraries=places"></script>
 

--- a/footprints/urls.py
+++ b/footprints/urls.py
@@ -171,9 +171,6 @@ urlpatterns = [
         PathmapperTableView.as_view(), name='pathmapper-table-view'),
     url(r'^pathmapper/vision/',
         TemplateView.as_view(template_name='design/pathmapper.html')),
-    url(r'^pathmapper/(?P<uuid>[0-9A-Za-z-]+)',
-        PathmapperView.as_view(),
-        name='pathmapper-share-view'),
     url(r'^pathmapper/', PathmapperView.as_view(), name='pathmapper-view'),
 
     # Temporary table view template for pathmapper

--- a/media/js/app/components/layerformvue.js
+++ b/media/js/app/components/layerformvue.js
@@ -5,7 +5,7 @@ define(['jquery', 'selectWidget'], function($, select) {
         data: function() {
             return {
                 layer: {
-                    'id': null,
+                    'layerId': null,
                     'title': '',
                     'work': null,
                     'imprint': null,

--- a/media/js/app/components/layerlistvue.js
+++ b/media/js/app/components/layerlistvue.js
@@ -32,7 +32,7 @@ define(['jquery', 'layerFormVue', 'utils'], function($, layerForm, utils) {
             saveLayer: function(layer) {
                 if (this.selectedLayerIdx === null) {
                     const idx = this.layers.push(layer);
-                    this.layers[idx-1].id = idx - 1;
+                    this.layers[idx-1].layerId = idx - 1;
                 } else {
                     this.layers[this.selectedLayerIdx] =
                         $.extend(true, {}, layer);

--- a/media/js/app/pathmapper.js
+++ b/media/js/app/pathmapper.js
@@ -11,7 +11,8 @@ requirejs(['./common'], function(common) {
                             id: null,
                             layers: []
                         },
-                        showMap: true
+                        showMap: true,
+                        shareUrl: Footprints.baseUrl + 'pathmapper/'
                     };
                 },
                 components: {
@@ -71,6 +72,36 @@ requirejs(['./common'], function(common) {
                             .removeClass('share-panel-expanded');
                         $('#share-panel-focus')
                             .addClass('share-panel-collapsed');
+                    },
+                    readShareData: function() {
+                        const j = document.getElementById('layers').textContent;
+                        const layers = JSON.parse(j);
+                        if (layers.length < 1) {
+                            return false;
+                        }
+                        // clear out the query parameters
+                        window.history.replaceState(
+                            {}, [], Footprints.baseUrl + 'pathmapper/');
+                        this.collection.layers = layers;
+                        return true;
+                    },
+                    updateShareUrl: function() {
+                        let url = Footprints.baseUrl + 'pathmapper/?';
+                        if (this.collection.layers.length < 1) {
+                            return url;
+                        }
+
+                        url += 'n=' + this.collection.layers.length + '&';
+                        this.collection.layers.forEach((layer, idx) => {
+                            // @todo - JSON.stringify layer here?
+                            url += 'l' + idx + '=';
+                            for (let [key, value] of Object.entries(layer)) {
+                                url += '"' + utils.abbreviate(key) + '":' +
+                                    (value || '') + ',';
+                            }
+                            url += '&';
+                        });
+                        this.shareUrl = url;
                     }
                 },
                 created: function() {
@@ -80,13 +111,16 @@ requirejs(['./common'], function(common) {
                     // eslint-disable-next-line
                     window.addEventListener('beforeunload', this.beforeUnload);
 
-                    // @todo accessing through a permalink
-
-                    // initialize layers via stored data
-                    this.readSession();
+                    // Accessing through a permalink?
+                    if (!this.readShareData()) {
+                        // otherwise, check to see if there is a saved
+                        // session. initialize layers via stored data
+                        this.readSession();
+                    }
                 },
                 updated: function() {
                     this.saveSession();
+                    this.updateShareUrl();
                 }
             });
         }

--- a/media/js/app/pathmapper.js
+++ b/media/js/app/pathmapper.js
@@ -96,7 +96,7 @@ requirejs(['./common'], function(common) {
                             // @todo - JSON.stringify layer here?
                             url += 'l' + idx + '=';
                             for (let [key, value] of Object.entries(layer)) {
-                                url += '"' + utils.abbreviate(key) + '":' +
+                                url += utils.abbreviate(key) + ':' +
                                     (value || '') + ',';
                             }
                             url += '&';

--- a/media/js/app/utils.js
+++ b/media/js/app/utils.js
@@ -1,4 +1,13 @@
 define(function() {
+    // Given a camel case string, return a string of upper-case letters
+    // :footprintStartDate" returns "fsd"
+    function abbreviate(str) {
+        return str
+            .split(/(?=[A-Z])/)
+            .map(word => word.charAt(0).toLowerCase())
+            .join('');
+    }
+
     // Simplifying this approach
     // https://stackoverflow.com/questions/50498666/nodejs-async-promise-queue
     class AsyncQueue {
@@ -271,6 +280,7 @@ define(function() {
     ]);
 
     return {
+        abbreviate: abbreviate,
         AsyncQueue: AsyncQueue,
         ajaxSetup: ajaxSetup,
         csrfSafeMethod: csrfSafeMethod,

--- a/requirements.txt
+++ b/requirements.txt
@@ -77,7 +77,7 @@ django-statsd-mozilla==0.4.0
 raven==6.10.0
 sentry-sdk==0.14.1
 django-bootstrap-form==3.4
-django-debug-toolbar==2.1
+django-debug-toolbar==1.9.1
 django-waffle==0.19.0
 django-smoketest==1.1.0
 django-extensions==2.2.6


### PR DESCRIPTION
On the client, a share url is constructed by compressing the the array of layers into a GET query parameter string. (Possible todo: retrieve a `tinyurl` for the long querystring.)

On the server, a valid share url is rehydrated into a layer array and placed in the view context. The client checks for valid layers in the view context and reads in the data if it exists.