### PR TITLE
Pathmapper Table: rethink data retrieval

### DIFF
--- a/footprints/main/serializers.py
+++ b/footprints/main/serializers.py
@@ -243,3 +243,31 @@ class PathmapperRouteSerializer(HyperlinkedModelSerializer):
     class Meta:
         model = BookCopy
         fields = ('id', 'imprint', 'footprints')
+
+
+class PathmapperTableRowSerializer(Serializer):
+    work_id = serializers.CharField(read_only=True)
+    work_title = serializers.CharField(
+        source='object.book_copy.imprint.work.title', read_only=True)
+    imprint_id = serializers.CharField(read_only=True)
+    imprint_title = serializers.CharField(
+        source='object.book_copy.imprint.display_title', read_only=True)
+    pub_date = serializers.CharField(
+        source='object.book_copy.imprint.publication_date')
+    pub_location = serializers.CharField(
+        source='imprint_location_title')
+    book_copy_identifier = serializers.CharField(read_only=True)
+    footprint_id = serializers.CharField(source='object_id', read_only=True)
+    footprint_title = serializers.CharField(source='title', read_only=True)
+    footprint_date = serializers.CharField(
+        source='object.associated_date', read_only=True)
+    footprint_location = serializers.CharField(
+        source='footprint_location_title')
+
+    class Meta:
+        fields = (
+            'work_id', 'work_title',
+            'imprint_id', 'imprint_title', 'pub_date', 'pub_location',
+            'book_copy_identifier',
+            'footprint_id', 'footprint_title', 'footprint_date',
+            'footprint_location')

--- a/footprints/pathmapper/forms.py
+++ b/footprints/pathmapper/forms.py
@@ -6,14 +6,13 @@ from django.utils.encoding import smart_text
 from haystack.forms import ModelSearchForm
 
 from footprints.main.models import (
-    BookCopy, Imprint, WrittenWork, Place, Actor)
+    BookCopy, Imprint, WrittenWork, Place, Actor, Footprint)
 from footprints.main.utils import camel_to_snake, snake_to_camel
 
 
 class ModelSearchFormEx(ModelSearchForm):
     q = forms.CharField(required=False)
 
-    work = forms.IntegerField(required=False)
     work = forms.IntegerField(required=False)
     imprint = forms.IntegerField(required=False)
 
@@ -225,6 +224,20 @@ class BookCopySearchForm(ModelSearchFormEx):
     def search(self):
         args, kwargs = self.arguments()
         return self.searchqueryset.filter(*args, **kwargs)
+
+
+class BookCopyFootprintsForm(ModelSearchForm):
+    ''' Given a list of bookcopies, retrieve the associated footprints'''
+    class Meta:
+        model = Footprint
+
+    def search(self, copies):
+        args = [Q(book_copy_id__in=copies)]
+        kwargs = {
+            'django_ct': 'main.footprint',
+        }
+        sqs = self.searchqueryset.filter(*args, **kwargs)
+        return sqs
 
 
 class ImprintSearchForm(ModelSearchFormEx):

--- a/footprints/templates/clientside/pathmapper_table.html
+++ b/footprints/templates/clientside/pathmapper_table.html
@@ -4,34 +4,56 @@
     <table class="table-pathmapper">
         <thead>
             <tr>
-                <th>Layer</th>
-                <th>Literary Work / Imprint</th>
-                <th>Book copy ID</th>
-                <th>Footprint place</th>
-                <th>Footprint date</th>
-                <th>Footprint title</th>
-                <th>Censor</th>
-                <th>Expurgator</th>
+                <th>Literary Work</th>
+                <th>Imprint</th>
+                <th>Book Copy</th>
+                <th class="footprint-title">Footprint Title</th>
+                <th>Footprint Date</th>
+                <th>Footprint Location</th>
             </tr>
         </thead>
         <tbody>
-            <tr v-for="(f, index) in footprints" :key="index">
-                <td>Layer Name</td>
-                <td>{{f.work_title}}<br />{{f.imprint_title}}</td>
-                <td>{{f.book_copy_identifier}}</td>
+            <tr v-for="(row, index) in rows" :key="index">
                 <td>
-                    <span v-if="f.place">
-                        {{f.place.display_title}}
+                    <a target="_blank" rel="noopener noreferrer"
+                        :href="'/writtenwork/' + row.work_id + '/'"
+                        :title="row.work_title">
+                        {{row.work_title}}
+                    </a>
+                </td>
+                <td>
+                    <a target="_blank" rel="noopener noreferrer"
+                        :href="'/writtenwork/' + row.work_id + '/' + row.imprint_id + '/'"
+                        :title="row.imprint_title">
+                        {{row.imprint_title}}
+                    </a><br />
+
+                    <span v-if="row.pub_date">{{row.pub_date}}</span><span v-if="row.pub_date && row.pub_location">, </span>
+                    <span v-if="row.pub_location">
+                        <span v-for="loc in parseArray(row.pub_location)">
+                            {{loc}}
+                        </span>
+                    </span>
+                </td>
+                <td>{{row.book_copy_identifier}}</td>
+                <td>
+                    <a :href="'/footprint/' + row.footprint_id + '/'"
+                        :title="'Link to footprint ' + row.footprint_title">
+                        {{row.footprint_title}}
+                    </a>
+                </td>
+                <td>
+                    <span v-if="row.footprint_date">
+                        {{row.footprint_date}}
                     </span>
                 </td>
                 <td>
-                    <span v-if="f.associated_date">
-                        {{f.associated_date.display}}
+                    <span v-if="row.footprint_location">
+                        <span v-for="loc in parseArray(row.footprint_location)">
+                            {{loc}}
+                        </span>
                     </span>
                 </td>
-                <td>{{f.title}}</td>
-                <td>Censor?</td>
-                <td>Expurgator</td>
             </tr>
         </tbody>
     </table>

--- a/media/css/pathmapper-tool.css
+++ b/media/css/pathmapper-tool.css
@@ -1,5 +1,10 @@
 /* --- PATHMAPPER tool --*/
 
+a {
+    color: #2e5367;
+    text-decoration: none;
+}
+
 .pathmapper-tool .content {
     margin: 0;
 }
@@ -573,11 +578,17 @@ header .btn-priority-hi {
 .table-pathmapper th, td {
     padding: 0.5rem;
 }
-.table-pathmapper th {
+.table-pathmapper td {
+    vertical-align: top;
 }
+
 .table-pathmapper tbody tr:nth-child(even) {background-color: #edeae6;}
 
 .table-pathmapper tbody tr:nth-child(odd) {background: #fafafa}
+
+.table-pathmapper th.footprint-title {
+    width: 25%;
+}
 
 /*
  *  STYLE 3

--- a/media/js/app/components/tableVue.js
+++ b/media/js/app/components/tableVue.js
@@ -6,12 +6,16 @@ define(['jquery', 'utils'], function($, utils) {
             return {
                 'page': {'number': 1, 'nextPage': null, 'prevPage': null},
                 'totalPages': 0,
-                'footprints': [],
+                'rows': [],
                 'baseUrl': Footprints.baseUrl,
                 'pageSize': 15
             };
         },
         methods: {
+            parseArray: function(s) {
+                s = s.replace(/'/g, '"');
+                return JSON.parse(s);
+            },
             hasNext: function() {
                 return this.page.nextPage;
             },
@@ -40,7 +44,7 @@ define(['jquery', 'utils'], function($, utils) {
                     this.page.nextPage = utils.parsePageNumber(data.next);
                     this.page.prevPage = utils.parsePageNumber(data.previous);
                     this.totalPages = Math.ceil(data.count / this.pageSize);
-                    this.footprints = $.extend(true, [], data.results);
+                    this.rows = $.extend(true, [], data.results);
                 });
             }
         },

--- a/media/js/app/utils.js
+++ b/media/js/app/utils.js
@@ -56,8 +56,8 @@ define(function() {
     function parsePageNumber(str) {
         let pageNumber = 1;
         try {
-            let result = str.matchAll(/page=(\d+)/);
-            pageNumber = parseInt(result.next().value[1], 10);
+            let result = str.match(/page=(\d+)/);
+            pageNumber = parseInt(result[1], 10);
         } catch (err) {
             // continue with default page number
         }


### PR DESCRIPTION
This PR leverages the Haystack SearchQuerySet to provide a reasonable default sort order for the set of footprints that are displayed in the pathmapper table. A new serializers also minimizes the json payload, returning the exact data needed to render the view.