### PR TITLE
Add Place: send up the geoname id

### DIFF
--- a/footprints/main/models.py
+++ b/footprints/main/models.py
@@ -638,9 +638,11 @@ class CanonicalPlace(models.Model):
     def longitude(self):
         return self.latlng.coords[0]
 
+    def latlng_string(self):
+        return '{},{}'.format(self.latitude(), self.longitude())
+
     def match_string(self, latlng):
-        s = '{},{}'.format(self.latitude(), self.longitude())
-        return s == latlng
+        return self.latlng_string() == latlng
 
 
 @python_2_unicode_compatible

--- a/footprints/main/tests/factories.py
+++ b/footprints/main/tests/factories.py
@@ -167,7 +167,7 @@ class CanonicalPlaceFactory(factory.DjangoModelFactory):
 
     canonical_name = 'Kraków, Poland'
     latlng = latlng = FuzzyPoint()
-    # string_to_point('50.064650,19.944979')
+    geoname_id = factory.Sequence(lambda n: 'geo%03d' % n)
 
     @factory.post_generation
     def position(self, create, extracted, **kwargs):

--- a/footprints/templates/xeditable/place.html
+++ b/footprints/templates/xeditable/place.html
@@ -16,7 +16,7 @@
             <div class="col-md-12">
                 <div class="form-group">
                     <label>Alternate Name (optional)</label>
-                    <input class="form-control" maxlength="256" name="alt-name" type="text" placeholder="Specify an alternate name..."/>
+                    <input class="form-control" maxlength="256" name="altname" type="text" placeholder="Specify an alternate name..."/>
                 </div>
             </div>
         </div>

--- a/media/js/xeditable/bootstrap-editable-place.js
+++ b/media/js/xeditable/bootstrap-editable-place.js
@@ -61,13 +61,13 @@ Place editable input.
             return str;
         },
         onPlaceClear: function() {
-            this.$altName.val('');
+            this.$altname.val('');
             if (this.marker) {
                 this.marker.setMap(null);
             }
         },
         onPlaceChange: function() {
-            const value = this.$geoName.select2('data')[0];
+            const value = this.$geoname.select2('data')[0];
 
             let latlng = new google.maps.LatLng(value.lat, value.lng);
 
@@ -97,7 +97,7 @@ Place editable input.
 
             this.$tpl.parents('.editable-input').addClass('wide');
 
-            this.$altName =
+            this.$altname =
                 this.$tpl.find('input[name="alt-name"]').first();
             this.mapContainer =
                 this.$tpl.find('.map-container')[0];
@@ -106,8 +106,8 @@ Place editable input.
                 this.mapContainer,
                 this.mapOptions);
 
-            this.$geoName = this.$tpl.find('[name="geoname"]').first();
-            this.$geoName.select2({
+            this.$geoname = this.$tpl.find('[name="geoname"]').first();
+            this.$geoname.select2({
                 allowClear: true,
                 placeholder: 'Search for a place...',
                 escapeMarkup: function(markup) {
@@ -240,8 +240,8 @@ Place editable input.
             if (this.marker !== undefined) {
                 values.latitude = this.marker.getPosition().lat();
                 values.longitude = this.marker.getPosition().lng();
-                values.geoName = this.$geoName.select2('data')[0].text;
-                values.altName = this.$altName.val();
+                values.geoname = this.$geoname.select2('data')[0].text;
+                values.altname = this.$altname.val();
             }
             return values;
         },
@@ -254,8 +254,8 @@ Place editable input.
         value2submit: function(values) {
             return {
                 position: this.marker.getPosition().toUrlValue(),
-                alternateName: values.altName,
-                canonicalName: values.geoName
+                alternateName: values.altname,
+                canonicalName: values.geoname
             };
         },
 
@@ -265,7 +265,7 @@ Place editable input.
            @method activate()
         **/
         activate: function() {
-            this.$geoName.focus();
+            this.$geoname.focus();
         },
 
         /**

--- a/media/js/xeditable/bootstrap-editable-place.js
+++ b/media/js/xeditable/bootstrap-editable-place.js
@@ -98,7 +98,7 @@ Place editable input.
             this.$tpl.parents('.editable-input').addClass('wide');
 
             this.$altname =
-                this.$tpl.find('input[name="alt-name"]').first();
+                this.$tpl.find('input[name="altname"]').first();
             this.mapContainer =
                 this.$tpl.find('.map-container')[0];
 
@@ -241,6 +241,7 @@ Place editable input.
                 values.latitude = this.marker.getPosition().lat();
                 values.longitude = this.marker.getPosition().lng();
                 values.geoname = this.$geoname.select2('data')[0].text;
+                values.geonameId = this.$geoname.select2('data')[0].id;
                 values.altname = this.$altname.val();
             }
             return values;
@@ -255,7 +256,8 @@ Place editable input.
             return {
                 position: this.marker.getPosition().toUrlValue(),
                 alternateName: values.altname,
-                canonicalName: values.geoname
+                canonicalName: values.geoname,
+                geonameId: values.geonameId
             };
         },
 


### PR DESCRIPTION
The geoname id will become (in essence) the primary key for the CanonicalPlace object. The client will now send up the id after a result has been selected.

@todo - A batch job will be constructed to retroactively populate the geoname id for existing CanonicalPlaces and hopefully clear up the duplication there.