### PR TITLE
Remove CanonicalPlace duplicates

### DIFF
--- a/footprints/main/management/commands/consolidate_canonical_places.py
+++ b/footprints/main/management/commands/consolidate_canonical_places.py
@@ -1,0 +1,42 @@
+from django.contrib.gis.db.models.functions import Distance
+from django.contrib.gis.measure import D
+from django.core.management.base import BaseCommand
+
+from footprints.main.models import CanonicalPlace
+
+
+class Command(BaseCommand):
+
+    def handle(self, *app_labels, **options):
+        processed = []
+        for cplace in CanonicalPlace.objects.filter():
+            if cplace.id in processed:
+                continue
+
+            # find matching places based on name and proximity
+            pnt = cplace.latlng
+            matches = CanonicalPlace.objects.exclude(id=cplace.id).filter(
+                canonical_name=cplace.canonical_name,
+                latlng__distance_lte=(pnt, D(mi=20))
+                ).annotate(d=Distance('latlng', pnt))
+
+            if matches.count() == 0:
+                continue
+
+            print('{}: {}'.format(cplace.id, cplace.canonical_name))
+            for match in matches:
+                print('    {}: {} {:.2f}'.format(
+                    match.id, match.canonical_name, match.d.mi))
+
+                for place in match.place_set.all():
+                    # detach references to this canonical place
+                    place.canonical_place = cplace
+                    place.save()
+
+                match.save()
+                processed.append(match.id)
+
+        # delete all deprecated canonical places
+        dups = CanonicalPlace.objects.filter(id__in=processed)
+        self.stdout.write('Removing {} duplicates'.format(dups.count()))
+        dups.delete()

--- a/footprints/main/tests/test_consolidate_canonical_places.py
+++ b/footprints/main/tests/test_consolidate_canonical_places.py
@@ -1,0 +1,54 @@
+from _io import StringIO
+
+from django.core.management import call_command
+from django.test import TestCase
+
+from footprints.main.models import CanonicalPlace
+from footprints.main.tests.factories import CanonicalPlaceFactory, PlaceFactory
+
+
+class ConsolidateCanonicalPlaces(TestCase):
+
+    def test_command(self):
+        cpMoscow1 = CanonicalPlaceFactory(
+            canonical_name='Moscow', position='55.755826,37.6173')
+        pMoscow1 = PlaceFactory(alternate_name='Moscow1',
+                                canonical_place=cpMoscow1)
+        cpMoscow2 = CanonicalPlaceFactory(
+            canonical_name='Moscow', position='55.755826,37.6174')
+        pMoscow2 = PlaceFactory(alternate_name='Moscow2',
+                                canonical_place=cpMoscow2)
+        cpMoscow3 = CanonicalPlaceFactory(
+            canonical_name='Moscow', position='55.755826,37.6175')
+        pMoscow3 = PlaceFactory(alternate_name='Moscow2',
+                                canonical_place=cpMoscow3)
+        cpMoscow4 = CanonicalPlaceFactory(
+            canonical_name='Moscow', position='55.755826,38.6175')
+        pMoscow4 = PlaceFactory(alternate_name='Moscow4',
+                                canonical_place=cpMoscow4)
+        cpMoskov1 = CanonicalPlaceFactory(
+            canonical_name='Moskov', position='55.755826,37.6173')
+        pMoskov1 = PlaceFactory(alternate_name='Moskov',
+                                canonical_place=cpMoskov1)
+
+        out = StringIO()
+        call_command('consolidate_canonical_places', stdout=out)
+        self.assertIn('Removing 2 duplicates', out.getvalue())
+        self.assertEqual(cpMoscow1.place_set.count(), 3)
+
+        with self.assertRaises(CanonicalPlace.DoesNotExist):
+            CanonicalPlace.objects.get(id=cpMoscow2.id)
+
+        with self.assertRaises(CanonicalPlace.DoesNotExist):
+            CanonicalPlace.objects.get(id=cpMoscow3.id)
+
+        pMoscow1.refresh_from_db()
+        self.assertEqual(pMoscow1.canonical_place, cpMoscow1)
+        pMoscow2.refresh_from_db()
+        self.assertEqual(pMoscow2.canonical_place, cpMoscow1)
+        pMoscow3.refresh_from_db()
+        self.assertEqual(pMoscow3.canonical_place, cpMoscow1)
+        pMoscow4.refresh_from_db()
+        self.assertEqual(pMoscow4.canonical_place, cpMoscow4)
+        pMoskov1.refresh_from_db()
+        self.assertEqual(pMoskov1.canonical_place, cpMoskov1)


### PR DESCRIPTION
Iterate CanonicalPlace instances and identify matches based on name and proximity.