### PR TITLE
Fix CanonicalPlace creation bug

### DIFF
--- a/footprints/main/admin.py
+++ b/footprints/main/admin.py
@@ -216,7 +216,7 @@ class CanonicalPlaceAdmin(admin.ModelAdmin):
         TextField: {'widget': TextInput},
     }
     list_display = (
-        'canonical_name', 'latitude', 'longitude')
+        'canonical_name', 'geoname_id', 'latitude', 'longitude')
     search_fields = ('canonical_name',)
 
     inlines = [

--- a/footprints/main/tests/factories.py
+++ b/footprints/main/tests/factories.py
@@ -166,7 +166,7 @@ class CanonicalPlaceFactory(factory.DjangoModelFactory):
         model = CanonicalPlace
 
     canonical_name = 'Kraków, Poland'
-    latlng = latlng = FuzzyPoint()
+    latlng = FuzzyPoint()
     geoname_id = factory.Sequence(lambda n: 'geo%03d' % n)
 
     @factory.post_generation

--- a/footprints/main/views.py
+++ b/footprints/main/views.py
@@ -675,7 +675,9 @@ class AddPlaceView(AddRelatedRecordView):
         except CanonicalPlace.DoesNotExist:
             latlng = string_to_point(position)
             canonical_place, created = CanonicalPlace.objects.get_or_create(
-                geoname_id=gid, latlng=latlng, canonical_name=canonical_name)
+                latlng=latlng, canonical_name=canonical_name)
+            canonical_place.geoname_id = gid
+            canonical_place.save()
 
         return canonical_place
 


### PR DESCRIPTION
CanonicalPlaces that existed without a geoname_id could error due to incorrect get_or_create signature. Added additional tests to uncover the bug.