### PR TITLE
Pathmapper: Date validation and explanatory text

### DIFF
--- a/footprints/templates/clientside/layer_form_template.html
+++ b/footprints/templates/clientside/layer_form_template.html
@@ -77,14 +77,17 @@
                 <div class="form-group row mb-1">
                     <label for="criteriaPubYearBegin" class="col-4 col-form-label">Publication:</label>
                     <div class="col-8 d-flex">
-                        <input v-model="layer.pubStart" type="text" class="form-control"
-                            id="criteriaPubYearBegin">
+                        <input v-model="layer.pubStart" class="form-control"
+                            id="criteriaPubYearBegin" type="number" :min="pubMin" :max="pubMax"
+                            v-on:blur="validateYear($event)">
+
                         <button type="button" v-on:click="togglePubRange"
                             :class="['btn', 'btn-outline-secondary', 'criteria-range', {'range-on': layer.pubRange}]">
                             <span v-if="layer.pubRange">to</span><span v-else>add range</span>
                         </button>
-                        <input v-if="layer.pubRange" v-model="layer.pubEnd" type="text" class="form-control"
-                            id="criteriaPubYearEnd">
+                        <input v-if="layer.pubRange" v-model="layer.pubEnd" class="form-control"
+                            id="criteriaPubYearEnd" type="number" :min="pubMin" :max="pubMax"
+                            v-on:blur.native="validateYear">
                     </div>
                 </div>
                 <div class="form-group row mb-2">
@@ -97,14 +100,16 @@
                 <div class="form-group mb-1 row">
                     <label for="criteriaFootprintYearBegin" class="col-4 col-form-label">Footprint:</label>
                     <div class="col-8 d-flex">
-                        <input v-model="layer.footprintStart" type="text" class="form-control"
-                            id="criteriaFootprintYearBegin">
+                        <input v-model="layer.footprintStart" class="form-control"
+                            id="criteriaFootprintYearBegin" type="number" :min="footprintMin" :max="footprintMax"
+                            v-on:blur.native="validateYear">
                         <button type="button" v-on:click="toggleFootprintRange"
                             :class="['btn', 'btn-outline-secondary', 'criteria-range', {'range-on': layer.footprintRange}]">
                             <span v-if="layer.footprintRange">to</span><span v-else>add range</span>
                         </button>
-                        <input v-if="layer.footprintRange" v-model="layer.footprintEnd" type="text" class="form-control"
-                            id="criteriaFootprintYearEnd">
+                        <input v-if="layer.footprintRange" v-model="layer.footprintEnd" class="form-control"
+                            id="criteriaFootprintYearEnd" type="number" :min="footprintMin" :max="footprintMax"
+                            v-on:blur.native="validateYear">
                     </div>
                 </div>
                 <div class="form-group row">

--- a/footprints/templates/clientside/layer_form_template.html
+++ b/footprints/templates/clientside/layer_form_template.html
@@ -72,48 +72,60 @@
                 <h2 id="region4">Years</h2>
 
                 <div class="form-group row mb-1">
-                    <div class="col-8 d-flex offset-4"><small>{{displayPubMinMax()}}</small></div>
+                    <div class="col-8 d-flex offset-4">
+                        <small v-if="validResults()">
+                            Publications range from {{pubMin}} to {{pubMax}}.
+                        </small>
+                    </div>
                 </div>
                 <div class="form-group row mb-1">
                     <label for="criteriaPubYearBegin" class="col-4 col-form-label">Publication:</label>
                     <div class="col-8 d-flex">
                         <input v-model="layer.pubStart" class="form-control"
-                            id="criteriaPubYearBegin" type="number" :min="pubMin" :max="pubMax"
-                            v-on:blur="validateYear($event)">
+                            id="criteriaPubYearBegin" type="number" :min="pubMin" :max="pubMax">
 
                         <button type="button" v-on:click="togglePubRange"
                             :class="['btn', 'btn-outline-secondary', 'criteria-range', {'range-on': layer.pubRange}]">
                             <span v-if="layer.pubRange">to</span><span v-else>add range</span>
                         </button>
                         <input v-if="layer.pubRange" v-model="layer.pubEnd" class="form-control"
-                            id="criteriaPubYearEnd" type="number" :min="pubMin" :max="pubMax"
-                            v-on:blur.native="validateYear">
+                            id="criteriaPubYearEnd" type="number" :min="pubMin" :max="pubMax">
                     </div>
                 </div>
                 <div class="form-group row mb-2">
-                    <div class="col-8 d-flex offset-4"><small>{{displayPubYearStatus()}}</small></div>
+                    <div :class="['col-8', 'd-flex', 'offset-4', {'is-invalid': !validPubRange}]">
+                        <small :class="[{'invalid-feedback': !validPubRange}]">
+                            {{displayPubRangeStatus()}}
+                        </small>
+                    </div>
                 </div>
 
                 <div class="form-group row mb-1">
-                    <div class="col-8 d-flex offset-4"><small>{{displayFootprintMinMax()}}</small></div>
+                    <div class="col-8 d-flex offset-4">
+                        <small v-if="validResults()">
+                            Footprints range from {{footprintMin}} to {{footprintMax}}.
+                        </small>
+                    </div>
                 </div>
                 <div class="form-group mb-1 row">
                     <label for="criteriaFootprintYearBegin" class="col-4 col-form-label">Footprint:</label>
                     <div class="col-8 d-flex">
                         <input v-model="layer.footprintStart" class="form-control"
-                            id="criteriaFootprintYearBegin" type="number" :min="footprintMin" :max="footprintMax"
-                            v-on:blur.native="validateYear">
+                            id="criteriaFootprintYearBegin" type="number" :min="footprintMin" :max="footprintMax">
                         <button type="button" v-on:click="toggleFootprintRange"
                             :class="['btn', 'btn-outline-secondary', 'criteria-range', {'range-on': layer.footprintRange}]">
                             <span v-if="layer.footprintRange">to</span><span v-else>add range</span>
                         </button>
                         <input v-if="layer.footprintRange" v-model="layer.footprintEnd" class="form-control"
-                            id="criteriaFootprintYearEnd" type="number" :min="footprintMin" :max="footprintMax"
-                            v-on:blur.native="validateYear">
+                            id="criteriaFootprintYearEnd" type="number" :min="footprintMin" :max="footprintMax">
                     </div>
                 </div>
                 <div class="form-group row">
-                    <div class="col-8 d-flex offset-4"><small>{{displayFootprintYearStatus()}}</small></div>
+                    <div class="col-8 d-flex offset-4">
+                        <small :class="[{'has-error': validFootprintRange()}]">
+                            {{displayFootprintRangeStatus()}}
+                        </small>
+                    </div>
                 </div>
 
             </section><!-- /#criteria-years -->

--- a/footprints/templates/clientside/layer_list_template.html
+++ b/footprints/templates/clientside/layer_list_template.html
@@ -8,7 +8,7 @@
                 :class="[{'d-none': !selectedLocation}]"/>
 
             <!-- Initial Create Layer pane -->
-            <form class="criteria-set-pane" :class="[{'d-none': selectedLocation}]"><!-- Begin form -->
+            <form id="create-layer-form" class="criteria-set-pane" :class="[{'d-none': selectedLocation}]"><!-- Begin form -->
                 <!-- Layer Create / Edit form -->
                 <layer-form v-if="selectedLayer" v-model="selectedLayer"
                     @save="saveLayer" @cancel="cancelLayer" 

--- a/media/js/app/components/layerformvue.js
+++ b/media/js/app/components/layerformvue.js
@@ -24,10 +24,10 @@ define(['jquery', 'selectWidget'], function($, select) {
                     'visible': true
                 },
                 total: null,
-                pubMin: null,
-                pubMax: null,
-                footprintMin: null,
-                footprintMax: null
+                pubMin: 1000,
+                pubMax: new Date().getFullYear(),
+                footprintMin: 1000,
+                footprintMax: new Date().getFullYear()
             };
         },
         computed: {
@@ -127,7 +127,9 @@ define(['jquery', 'selectWidget'], function($, select) {
                 this.$emit('cancel');
             },
             save: function() {
-                this.$emit('save', $.extend(true, {}, this.layer));
+                if (document.forms['create-layer-form'].reportValidity()) {
+                    this.$emit('save', $.extend(true, {}, this.layer));
+                }
             },
             togglePane: function() {
                 if ($('#container-pane').hasClass('widget-pane-expanded')) {
@@ -149,6 +151,9 @@ define(['jquery', 'selectWidget'], function($, select) {
                 if (!this.layer.footprintRange) {
                     this.layer.footprintEnd = null;
                 }
+            },
+            validateYear: function(event) {
+                event.target.reportValidity();
             }
         },
         created: function() {


### PR DESCRIPTION
This PR clarifies the date validation and explanatory text around the pathmapper publication and footprint date entry. This is a complicated little bit of UI, but here are the basics.

1. As a user selects criteria within the Pathmapper form, the line above the date range inputs displays the bounds of the resulting data set. In this case, the user has searched for the literary work "Abudarham" resulting in 29 book copies that were published between 1489 to 1726.

2. The line below the date range inputs offer direction on what the user has entered. In this example, the user has started to a type a year and is instructed that the start year must be between 1000 - 2020. Many permutations are handled here as the date range inputs handle a single year, a start year with an open end year, and an open start year with an end year.

![Screen Shot 2020-06-06 at 4 28 16 PM](https://user-images.githubusercontent.com/141369/83953948-ca971c80-a812-11ea-9765-bc7231cdf262.png)

Lots of design work to do here still.
