### PR TITLE
Pathmapper: switch to using CanonicalPlace

### DIFF
--- a/footprints/main/serializers.py
+++ b/footprints/main/serializers.py
@@ -9,7 +9,7 @@ from rest_framework.serializers import Serializer, HyperlinkedModelSerializer
 from footprints.main.models import Footprint, Language, Role, Actor, \
     ExtendedDate, Person, Place, WrittenWork, Imprint, BookCopy, \
     StandardizedIdentification, DigitalObject, DigitalFormat, \
-    StandardizedIdentificationType
+    StandardizedIdentificationType, CanonicalPlace
 
 
 class NameSerializer(Serializer):
@@ -95,13 +95,24 @@ class PersonSerializer(HyperlinkedModelSerializer):
                   'standardized_identifier')
 
 
-class PlaceSerializer(HyperlinkedModelSerializer):
+class CanonicalPlaceSerializer(HyperlinkedModelSerializer):
     latitude = ReadOnlyField()
     longitude = ReadOnlyField()
 
     class Meta:
+        model = CanonicalPlace
+        fields = ('id', 'canonical_name', 'latitude', 'longitude')
+
+
+class PlaceSerializer(HyperlinkedModelSerializer):
+    latitude = ReadOnlyField()
+    longitude = ReadOnlyField()
+    canonical_place = CanonicalPlaceSerializer()
+
+    class Meta:
         model = Place
-        fields = ('id', 'display_title', 'latitude', 'longitude')
+        fields = ('id', 'display_title', 'canonical_place',
+                  'latitude', 'longitude')
 
 
 class DigitalObjectSerializer(HyperlinkedModelSerializer):

--- a/media/js/app/components/layermapvue.js
+++ b/media/js/app/components/layermapvue.js
@@ -45,8 +45,8 @@ define(['jquery', 'utils'], function($, utils) {
                     lng: bookcopy.imprint.place.longitude
                 };
                 return this.addPoint(
-                    bookcopy.imprint.place.id,
-                    bookcopy.imprint.place.display_title,
+                    bookcopy.imprint.place.canonical_place.id,
+                    bookcopy.imprint.place.canonical_place.canonical_name,
                     'initial', bookcopy, null, latlng,
                     Date.parse(bookcopy.imprint.sort_date));
             },
@@ -56,7 +56,8 @@ define(['jquery', 'utils'], function($, utils) {
                     lng: footprint.place.longitude
                 };
                 return this.addPoint(
-                    footprint.place.id, footprint.place.display_title,
+                    footprint.place.canonical_place.id,
+                    footprint.place.canonical_place.canonical_name,
                     'interim', bookcopy, footprint, latlng,
                     Date.parse(footprint.sort_date));
             },


### PR DESCRIPTION
* Add CanonicalPlace serializers
* Use this as the primary key in mapping places

Note: I'm choosing to leave the PlaceSerializer fields in place for the moment. Those will need to be factored out of other areas in the application.