### PR TITLE
Change Footprint & Imprint locations to index by CanonicalPlace

### DIFF
--- a/footprints/main/search_indexes.py
+++ b/footprints/main/search_indexes.py
@@ -73,14 +73,14 @@ class WrittenWorkIndex(CelerySearchIndex, Indexable):
         places = []
         for f in obj.footprints():
             if f.place:
-                places.append(f.place.id)
+                places.append(f.place.canonical_place.id)
         return places
 
     def prepare_imprint_location(self, obj):
         places = []
         for imprint in obj.imprints():
             if imprint.place:
-                places.append(imprint.place.id)
+                places.append(imprint.place.canonical_place.id)
         return places
 
     def _actors(self, obj):
@@ -141,26 +141,27 @@ class ImprintIndex(CelerySearchIndex, Indexable):
 
     def prepare_imprint_location(self, obj):
         if obj.place:
-            return [obj.place.id]
+            return [obj.place.canonical_place.id]
         return []
 
     def prepare_imprint_location_title(self, obj):
         if obj.place:
-            return [smart_text(obj.place)]
+            return [smart_text(obj.place.canonical_place.canonical_name)]
         return []
 
     def prepare_footprint_location(self, obj):
         places = []
         for f in obj.footprints():
             if f.place:
-                places.append(f.place.id)
+                places.append(f.place.canonical_place.id)
         return places
 
     def prepare_footprint_location_title(self, obj):
         places = []
         for f in obj.footprints():
             if f.place:
-                places.append(smart_text(f.place))
+                name = f.place.canonical_place.canonical_name
+                places.append(smart_text(name))
         return places
 
     def _actors(self, obj):
@@ -221,26 +222,28 @@ class BookCopyIndex(CelerySearchIndex, Indexable):
 
     def prepare_imprint_location(self, obj):
         if obj.imprint.place:
-            return [obj.imprint.place.id]
+            return [obj.imprint.place.canonical_place.id]
         return []
 
     def prepare_imprint_location_title(self, obj):
         if obj.imprint.place:
-            return [smart_text(obj.imprint.place)]
+            name = smart_text(obj.imprint.place.canonical_place.canonical_name)
+            return [name]
         return []
 
     def prepare_footprint_location(self, obj):
         places = []
         for f in obj.footprints():
             if f.place:
-                places.append(f.place.id)
+                places.append(f.place.canonical_place.id)
         return places
 
     def prepare_footprint_location_title(self, obj):
         places = []
         for f in obj.footprints():
             if f.place:
-                places.append(smart_text(f.place))
+                name = smart_text(f.place.canonical_place.canonical_name)
+                places.append(name)
         return places
 
     def prepare_actor(self, obj):
@@ -349,25 +352,26 @@ class FootprintIndex(CelerySearchIndex, Indexable):
 
     def prepare_footprint_location(self, obj):
         if obj.place:
-            return [obj.place.id]
+            return [obj.place.canonical_place.id]
 
         return []
 
     def prepare_footprint_location_title(self, obj):
         if obj.place:
-            return [smart_text(obj.place)]
+            return [smart_text(obj.place.canonical_place.canonical_name)]
 
         return []
 
     def prepare_imprint_location(self, obj):
         if obj.book_copy.imprint.place:
-            return [obj.book_copy.imprint.place.id]
+            return [obj.book_copy.imprint.place.canonical_place.id]
 
         return []
 
     def prepare_imprint_location_title(self, obj):
         if obj.book_copy.imprint.place:
-            return [smart_text(obj.book_copy.imprint.place)]
+            place = obj.book_copy.imprint.place
+            return [smart_text(place.canonical_place.canonical_name)]
 
         return []
 

--- a/footprints/main/tests/test_search_indexes.py
+++ b/footprints/main/tests/test_search_indexes.py
@@ -30,7 +30,7 @@ class TestBookCopyIndex(TestCase):
     def test_prepare_footprint_locations(self):
         fp = FootprintFactory()
         places = BookCopyIndex().prepare_footprint_location(fp.book_copy)
-        self.assertTrue(fp.place.id in places)
+        self.assertTrue(fp.place.canonical_place.id in places)
 
     def test_prepare_actor(self):
         fp = FootprintFactory()
@@ -55,7 +55,7 @@ class TestImprintIndex(TestCase):
         fp = FootprintFactory()
         places = ImprintIndex().prepare_footprint_location(
             fp.book_copy.imprint)
-        self.assertTrue(fp.place.id in places)
+        self.assertTrue(fp.place.canonical_place.id in places)
 
     def test_prepare_actor(self):
         fp = FootprintFactory()
@@ -77,13 +77,14 @@ class TestWrittenWorkIndex(TestCase):
         fp = FootprintFactory()
         places = WrittenWorkIndex().prepare_footprint_location(
             fp.book_copy.imprint.work)
-        self.assertTrue(fp.place.id in places)
+        self.assertTrue(fp.place.canonical_place.id in places)
 
     def test_prepare_imprint_location(self):
         fp = FootprintFactory()
         places = WrittenWorkIndex().prepare_imprint_location(
             fp.book_copy.imprint.work)
-        self.assertTrue(fp.book_copy.imprint.place.id in places)
+        self.assertTrue(
+            fp.book_copy.imprint.place.canonical_place.id in places)
 
     def test_prepare_actor(self):
         fp = FootprintFactory()

--- a/footprints/main/viewsets.py
+++ b/footprints/main/viewsets.py
@@ -4,14 +4,14 @@ from rest_framework import viewsets
 from footprints.main.models import (
     Footprint, Actor, Person, Role, WrittenWork, Language, ExtendedDate,
     Place, Imprint, BookCopy, StandardizedIdentification, DigitalFormat,
-    DigitalObject, StandardizedIdentificationType)
+    DigitalObject, StandardizedIdentificationType, CanonicalPlace)
 from footprints.main.serializers import (
     FootprintSerializer, LanguageSerializer, RoleSerializer,
     ExtendedDateSerializer, ActorSerializer, PersonSerializer,
     PlaceSerializer, WrittenWorkSerializer, ImprintSerializer,
     BookCopySerializer, StandardizedIdentificationSerializer,
     DigitalFormatSerializer, DigitalObjectSerializer,
-    StandardizedIdentificationTypeSerializer)
+    StandardizedIdentificationTypeSerializer, CanonicalPlaceSerializer)
 from footprints.pathmapper.forms import (
     ActorSearchForm,
     ImprintSearchForm, WrittenWorkSearchForm, PlaceSearchForm)
@@ -43,8 +43,8 @@ class PersonViewSet(viewsets.ModelViewSet):
 
 
 class PlaceViewSet(viewsets.ModelViewSet):
-    model = Place
-    serializer_class = PlaceSerializer
+    model = CanonicalPlace
+    serializer_class = CanonicalPlaceSerializer
 
     def get_queryset(self):
         form = PlaceSearchForm(self.request.GET)
@@ -55,16 +55,16 @@ class PlaceViewSet(viewsets.ModelViewSet):
             else:
                 ids = form.search()
 
-            qs = Place.objects.filter(id__in=ids)
+            qs = CanonicalPlace.objects.filter(id__in=ids)
 
             q = form.cleaned_data.get('q', '')
             if q:
                 qs = qs.filter(
-                    Q(alternate_name__contains=q) |
+                    Q(place__alternate_name__contains=q) |
                     Q(canonical_place__canonical_name__contains=q))
 
-            return qs
-        return Place.objects.none()
+            return qs.distinct()
+        return CanonicalPlace.objects.none()
 
 
 class AlternatePlaceNameViewSet(viewsets.ModelViewSet):

--- a/footprints/pathmapper/forms.py
+++ b/footprints/pathmapper/forms.py
@@ -112,11 +112,11 @@ class ModelSearchFormEx(ModelSearchForm):
         return kwargs
 
     def handle_imprint_location(self):
-        args = []
+        kwargs = {}
         loc = self.cleaned_data.get('imprint_location')
         if loc:
-            args.append(Q(imprint_location_exact__in=[loc]))
-        return args
+            kwargs['imprint_location'] = loc
+        return kwargs
 
     def handle_imprint_location_title(self):
         args = []
@@ -130,11 +130,11 @@ class ModelSearchFormEx(ModelSearchForm):
         return args
 
     def handle_footprint_location(self):
-        args = []
+        kwargs = {}
         loc = self.cleaned_data.get('footprint_location')
         if loc:
-            args.append(Q(footprint_location_exact__in=[loc]))
-        return args
+            kwargs['footprint_location'] = loc
+        return kwargs
 
     def handle_footprint_location_title(self):
         args = []
@@ -210,8 +210,8 @@ class BookCopySearchForm(ModelSearchFormEx):
         if imprint_id:
             kwargs['imprint_id'] = imprint_id
 
-        args += self.handle_imprint_location()
-        args += self.handle_footprint_location()
+        kwargs.update(self.handle_imprint_location())
+        kwargs.update(self.handle_footprint_location())
         args += self.handle_actor()
 
         kwargs.update(self.handle_boolean('censored'))
@@ -262,8 +262,8 @@ class ImprintSearchForm(ModelSearchFormEx):
         if imprint_id:
             kwargs['object_id'] = imprint_id
 
-        args += self.handle_imprint_location()
-        args += self.handle_footprint_location()
+        kwargs.update(self.handle_imprint_location())
+        kwargs.update(self.handle_footprint_location())
         args += self.handle_actor()
 
         kwargs.update(self.handle_pub_year())
@@ -294,8 +294,8 @@ class WrittenWorkSearchForm(ModelSearchFormEx):
         if work_id:
             kwargs['object_id'] = work_id
 
-        args += self.handle_imprint_location()
-        args += self.handle_footprint_location()
+        kwargs.update(self.handle_imprint_location())
+        kwargs.update(self.handle_footprint_location())
         args += self.handle_actor()
 
         kwargs.update(self.handle_pub_year())
@@ -330,11 +330,7 @@ class PlaceSearchForm(ModelSearchFormEx):
         if imprint_id:
             kwargs['imprint_id'] = imprint_id
 
-        args += self.handle_imprint_location_title()
-
-        q = self.cleaned_data.get('q', '')
-        if q:
-            args.append(Q(footprint_location_title__contains=q))
+        kwargs.update(self.handle_imprint_location())
 
         sqs = self.searchqueryset.filter(*args, **kwargs)
         counts = sqs.facet('footprint_location').facet_counts()
@@ -348,11 +344,7 @@ class PlaceSearchForm(ModelSearchFormEx):
         if imprint_id:
             kwargs['object_id'] = imprint_id
 
-        args += self.handle_footprint_location_title()
-
-        q = self.cleaned_data.get('q', '')
-        if q:
-            args.append(Q(imprint_location_title__contains=q))
+        kwargs.update(self.handle_footprint_location())
 
         sqs = self.searchqueryset.filter(*args, **kwargs)
         counts = sqs.facet('imprint_location').facet_counts()
@@ -399,9 +391,8 @@ class ActorSearchForm(ModelSearchFormEx):
         if imprint_id:
             kwargs['imprint_id'] = imprint_id
 
-        args += self.handle_imprint_location()
-        args += self.handle_footprint_location()
-
+        kwargs.update(self.handle_imprint_location())
+        kwargs.update(self.handle_footprint_location())
         kwargs.update(self.handle_pub_year())
         kwargs.update(self.handle_footprint_year())
         return args, kwargs

--- a/footprints/pathmapper/tests/test_forms.py
+++ b/footprints/pathmapper/tests/test_forms.py
@@ -97,8 +97,8 @@ class ModelSearchFormExTest(TestCase):
             'imprint_location': 1
         }
 
-        args = form.handle_imprint_location()
-        self.assertEqual(args[0], Q(imprint_location_exact__in=[1]))
+        kwargs = form.handle_imprint_location()
+        self.assertEqual(kwargs['imprint_location'], 1)
 
     def test_handle_imprint_location_title(self):
         place = PlaceFactory()
@@ -117,8 +117,8 @@ class ModelSearchFormExTest(TestCase):
             'footprint_location': 1
         }
 
-        args = form.handle_footprint_location()
-        self.assertEqual(args[0], Q(footprint_location_exact__in=[1]))
+        kwargs = form.handle_footprint_location()
+        self.assertEqual(kwargs['footprint_location'], 1)
 
     def test_handle_footprint_location_title(self):
         place = PlaceFactory()
@@ -269,9 +269,9 @@ class BookCopySearchFormTest(TestCase):
         self.assertEqual(kwargs['django_ct'], 'main.bookcopy')
         self.assertEqual(kwargs['work_id'], 12)
         self.assertEqual(kwargs['imprint_id'], 13)
-        self.assertEqual(args[0], Q(imprint_location_exact__in=[14]))
-        self.assertEqual(args[1], Q(footprint_location_exact__in=[15]))
-        self.assertEqual(args[2], Q(actor_exact__in=[16]))
+        self.assertEqual(kwargs['imprint_location'], 14)
+        self.assertEqual(kwargs['footprint_location'], 15)
+        self.assertEqual(args[0], Q(actor_exact__in=[16]))
         self.assertEqual(kwargs['footprint_start_date__gte'], date(1910, 1, 1))
         self.assertEqual(
             kwargs['footprint_end_date__lte'], date(1940, 12, 31))
@@ -291,9 +291,9 @@ class ImprintSearchFormTest(TestCase):
         self.assertEqual(kwargs['content'], 'Foo')
         self.assertEqual(kwargs['work_id'], 12)
         self.assertFalse('imprint_id' in kwargs)
-        self.assertEqual(args[0], Q(imprint_location_exact__in=[14]))
-        self.assertEqual(args[1], Q(footprint_location_exact__in=[15]))
-        self.assertEqual(args[2], Q(actor_exact__in=[16]))
+        self.assertEqual(kwargs['imprint_location'], 14)
+        self.assertEqual(kwargs['footprint_location'], 15)
+        self.assertEqual(args[0], Q(actor_exact__in=[16]))
         self.assertEqual(kwargs['footprint_start_date__gte'], date(1910, 1, 1))
         self.assertEqual(
             kwargs['footprint_end_date__lte'], date(1940, 12, 31))
@@ -313,9 +313,9 @@ class WrittenWorkSearchFormTest(TestCase):
         self.assertEqual(kwargs['content'], 'Foo')
         self.assertFalse('work_id' in kwargs)
         self.assertFalse('imprint_id' in kwargs)
-        self.assertEqual(args[0], Q(imprint_location_exact__in=[14]))
-        self.assertEqual(args[1], Q(footprint_location_exact__in=[15]))
-        self.assertEqual(args[2], Q(actor_exact__in=[16]))
+        self.assertEqual(kwargs['imprint_location'], 14)
+        self.assertEqual(kwargs['footprint_location'], 15)
+        self.assertEqual(args[0], Q(actor_exact__in=[16]))
         self.assertEqual(kwargs['footprint_start_date__gte'], date(1910, 1, 1))
         self.assertEqual(
             kwargs['footprint_end_date__lte'], date(1940, 12, 31))
@@ -338,8 +338,8 @@ class ActorSearchFormTest(TestCase):
         self.assertEqual(args[1], Q(actor_title_exact__contains='Foo'))
         self.assertEqual(kwargs['work_id'], 12)
         self.assertEqual(kwargs['imprint_id'], 13)
-        self.assertEqual(args[2], Q(imprint_location_exact__in=[14]))
-        self.assertEqual(args[3], Q(footprint_location_exact__in=[15]))
+        self.assertEqual(kwargs['imprint_location'], 14)
+        self.assertEqual(kwargs['footprint_location'], 15)
         self.assertEqual(kwargs['footprint_start_date__gte'], date(1910, 1, 1))
         self.assertEqual(
             kwargs['footprint_end_date__lte'], date(1940, 12, 31))

--- a/footprints/templates/search/indexes/main/footprint_text.txt
+++ b/footprints/templates/search/indexes/main/footprint_text.txt
@@ -1,8 +1,10 @@
 {{object.title}}
 {{object.notes}}
 {{object.book_copy.imprint.work.title}}
-{{object.place.display_title}}
-{{object.book_copy.imprint.place.display_title}}
+{{object.place.alternate_name}}
+{{object.place.canonical_place.canonical_name}}
+{{object.book_copy.imprint.place.alternate_name}}
+{{object.book_copy.imprint.place.canonical_place.canonical_name}}
 {{object.book_copy.call_number}}
 {{object.book_copy.imprint.get_bhb_number}}
 {% for actor in object.actor.all %}

--- a/footprints/templates/search/indexes/main/writtenwork_text.txt
+++ b/footprints/templates/search/indexes/main/writtenwork_text.txt
@@ -1,8 +1,2 @@
 {{object.title}}
 {{object.notes}}
-{% for imprint in object.imprints %}
-    {{imprint.place.city}} {{imprint.place.country}}
-{% endfor %}
-{% for author in object.authors %}
-    {{author.person.name}} {{author.alias}}
-{% endfor %}

--- a/media/js/app/components/select-widget.js
+++ b/media/js/app/components/select-widget.js
@@ -48,9 +48,10 @@ define(['jquery', 'select2'], function($, select2) {
                     processResults: function(data, params) {
                         let results = $.map(data.results, function(obj) {
                             obj.text = obj.title || obj.search_title ||
-                                obj.display_title || obj.display_name;
+                                obj.display_title || obj.display_name ||
+                                obj.canonical_name;
                             obj.html = obj.description || obj.search_title ||
-                                obj.display_title;
+                                obj.display_title || obj.canonical_name;
                             return obj;
                         });
 
@@ -79,7 +80,8 @@ define(['jquery', 'select2'], function($, select2) {
                 }).done((data) => {
                     if (data.results.length > 0) {
                         const item = data.results[0];
-                        const title = item.title || item.display_title;
+                        const title = item.title || item.display_title ||
+                            item.canonical_name;
                         const value = item.id;
                         const option = new Option(title, value, true, true);
                         $(this.$el).append(option).trigger('change');


### PR DESCRIPTION
* Update the Solr index to use CanonicalPlace for the Footprint location and Imprint location.
* Pathmapper now works with the CanonicalPlace id rather than attempting matches against the title.

Important: This change will require a full Solr index rebuild. Please review & approve the PR, but wait to merge.
