### PR TITLE
Temporary fix for going to layer list panel

### DIFF
--- a/footprints/templates/clientside/layer_form_template.html
+++ b/footprints/templates/clientside/layer_form_template.html
@@ -2,7 +2,7 @@
 <script type="text/x-template" id="layer-template">
     <div class="pane-content" id="create-layer-init">
         <header class="d-flex flex-row">
-            <h1><i class="fas fa-layer-group mr-2" aria-hidden="true"></i>
+            <h1><i class="fas fa-layer-group mr-2 fa-cancel-form" v-on:click="cancel" aria-hidden="true"></i><!-- temporary fix -->
                 <span v-if="layer.id !== null">Edit Layer</span>
                 <span v-else>New layer</span>
             </h1>

--- a/media/css/pathmapper-tool.css
+++ b/media/css/pathmapper-tool.css
@@ -198,6 +198,11 @@ a {
     color: #333;
 }
 
+.pane-content header .fa-cancel-form {
+    cursor: pointer;
+    color: #97421b;
+}
+
 label.layer-title {
     margin: 0 0.5rem 0 0;
     line-height: 3.25rem;


### PR DESCRIPTION
The layer icon on the header of the panel is, for now, a way to return to layer list. It's not the ideal location, but a temporary fix.

![Screen Shot 2020-06-21 at 2 40 55 PM](https://user-images.githubusercontent.com/976843/85232517-4a091c00-b3cd-11ea-8c68-a147d0edf1de.png)
