### PR TITLE
Pin the highcharts & heatmap versions

### DIFF
--- a/footprints/templates/pathmapper/map.html
+++ b/footprints/templates/pathmapper/map.html
@@ -98,8 +98,8 @@
     <script type="text/javascript"
         src="//maps.google.com/maps/api/js?key={{settings.GOOGLE_MAP_API}}&libraries=places"></script>
 
-    <script src="https://code.highcharts.com/highcharts.js"></script>
-    <script src="https://code.highcharts.com/modules/heatmap.js"></script>
+    <script src="https://code.highcharts.com/8.2.0/highcharts.js"></script>
+    <script src="https://code.highcharts.com/8.2.0/modules/heatmap.js"></script>
 
     <script data-main="{{STATIC_URL}}js/app/pathmapper.js"
         src="{{STATIC_URL}}js/lib/require/require.js"></script>

--- a/footprints/templates/pathmapper/map.html
+++ b/footprints/templates/pathmapper/map.html
@@ -98,7 +98,7 @@
     <script type="text/javascript"
         src="//maps.google.com/maps/api/js?key={{settings.GOOGLE_MAP_API}}&libraries=places"></script>
 
-    <script src="https://code.highcharts.com/8.1/highcharts.src.js"></script>
+    <script src="https://code.highcharts.com/highcharts.js"></script>
     <script src="https://code.highcharts.com/modules/heatmap.js"></script>
 
     <script data-main="{{STATIC_URL}}js/app/pathmapper.js"


### PR DESCRIPTION
The code was previously importing a certain version (8.1) of the core highcharts and the "stable" version of heatmap, which resulted in a conflict. Pin both to a known version to prevent unexpected issues.