### PR TITLE
Haystack search templates: turn off escaping 

### DIFF
--- a/footprints/templates/search/indexes/main/actor_text.txt
+++ b/footprints/templates/search/indexes/main/actor_text.txt
@@ -1,3 +1,5 @@
+{% autoescape off %}
 {{object.person.name}}
 {{object.alias}}
 {{object.notes}}
+{% endautoescape %}

--- a/footprints/templates/search/indexes/main/bookcopy_text.txt
+++ b/footprints/templates/search/indexes/main/bookcopy_text.txt
@@ -1,2 +1,4 @@
+{% autoescape off %}
 {{object.imprint.title}}
 {{object.imprint.work.title}}
+{% endautoescape %}

--- a/footprints/templates/search/indexes/main/footprint_text.txt
+++ b/footprints/templates/search/indexes/main/footprint_text.txt
@@ -1,3 +1,4 @@
+{% autoescape off %}
 {{object.title}} {{object.created_by.get_full_name}} {{object.book_copy.imprint.work.title}}
 {{object.place.alternate_name}}
 {{object.place.canonical_place.canonical_name}}
@@ -5,8 +6,7 @@
 {{object.book_copy.imprint.place.canonical_place.canonical_name}}
 {{object.book_copy.call_number}}
 {{object.book_copy.imprint.get_bhb_number}}
-{% autoescape off %}
 {% for actor in object.actor.all %} {{actor}} {% endfor %}
 {% for actor in object.book_copy.imprint.work.actor.all %} {{actor}} {% endfor %}
-{% endautoescape %}
 {{object.notes}}
+{% endautoescape %}

--- a/footprints/templates/search/indexes/main/footprint_text.txt
+++ b/footprints/templates/search/indexes/main/footprint_text.txt
@@ -5,6 +5,8 @@
 {{object.book_copy.imprint.place.canonical_place.canonical_name}}
 {{object.book_copy.call_number}}
 {{object.book_copy.imprint.get_bhb_number}}
+{% autoescape off %}
 {% for actor in object.actor.all %} {{actor}} {% endfor %}
 {% for actor in object.book_copy.imprint.work.actor.all %} {{actor}} {% endfor %}
+{% endautoescape %}
 {{object.notes}}

--- a/footprints/templates/search/indexes/main/footprint_text_exact.txt
+++ b/footprints/templates/search/indexes/main/footprint_text_exact.txt
@@ -1,3 +1,4 @@
+{% autoescape off %}
 {{object.title}} {{object.created_by.get_full_name}} {{object.book_copy.imprint.work.title}}
 {{object.place.alternate_name}}
 {{object.place.canonical_place.canonical_name}}
@@ -5,8 +6,7 @@
 {{object.book_copy.imprint.place.canonical_place.canonical_name}}
 {{object.book_copy.call_number}}
 {{object.book_copy.imprint.get_bhb_number}}
-{% autoescape off %}
 {% for actor in object.actor.all %} {{actor}} {% endfor %}
 {% for actor in object.book_copy.imprint.work.actor.all %} {{actor}} {% endfor %}
-{% endautoescape %}
 {{object.notes}}
+{% endautoescape %}

--- a/footprints/templates/search/indexes/main/footprint_text_exact.txt
+++ b/footprints/templates/search/indexes/main/footprint_text_exact.txt
@@ -5,6 +5,8 @@
 {{object.book_copy.imprint.place.canonical_place.canonical_name}}
 {{object.book_copy.call_number}}
 {{object.book_copy.imprint.get_bhb_number}}
+{% autoescape off %}
 {% for actor in object.actor.all %} {{actor}} {% endfor %}
 {% for actor in object.book_copy.imprint.work.actor.all %} {{actor}} {% endfor %}
+{% endautoescape %}
 {{object.notes}}

--- a/footprints/templates/search/indexes/main/imprint_text.txt
+++ b/footprints/templates/search/indexes/main/imprint_text.txt
@@ -1,2 +1,4 @@
+{% autoescape off %}
 {{object.title}}
 {{object.notes}}
+{% endautoescape %}

--- a/footprints/templates/search/indexes/main/person_text.txt
+++ b/footprints/templates/search/indexes/main/person_text.txt
@@ -1,2 +1,6 @@
+{% autoescape off %}
 {{object.name}}
-{{object.notes}}
+{% if object.notes %}
+    {{object.notes}}
+{% endif %}
+{% endautoescape %}

--- a/footprints/templates/search/indexes/main/place_text.txt
+++ b/footprints/templates/search/indexes/main/place_text.txt
@@ -1,1 +1,3 @@
+{% autoescape off %}
 {{object.display_title}}
+{% endautoescape %}

--- a/footprints/templates/search/indexes/main/writtenwork_text.txt
+++ b/footprints/templates/search/indexes/main/writtenwork_text.txt
@@ -1,2 +1,4 @@
+{% autoescape off %}
 {{object.title}}
 {{object.notes}}
+{% endautoescape %}


### PR DESCRIPTION
By default, Django templates autoescape special characters, such as apostrophes. This PR turns off autoescape when processing the search templates for Solr. Once the core is reindexed, search results should be more consistent for these corner cases.