### PR TITLE
Remove special handling for utf-8 encoding

### DIFF
--- a/footprints/main/tests/test_utils.py
+++ b/footprints/main/tests/test_utils.py
@@ -34,9 +34,9 @@ class CustomUtilsTest(TestCase):
 
         # roles and actors should return the string you expect
         array = interpolate_role_actors(roles, actors)
-        self.assertTrue(array[0].count(b'Nick (Author)') == 1)
-        self.assertTrue(array[2].count(b'Nick (Printer)') == 1)
-        self.assertTrue(array[4].count(b'Nick (Censor)') == 1)
+        self.assertTrue(array[0].count('Nick (Author)') == 1)
+        self.assertTrue(array[2].count('Nick (Printer)') == 1)
+        self.assertTrue(array[4].count('Nick (Censor)') == 1)
 
         # roles and multiple actors should put all the actors of a given role
         # into the same col
@@ -44,9 +44,9 @@ class CustomUtilsTest(TestCase):
             'Nick', 1234, role1, '11/09/84', '11/09/17')
         actors.append(actor4)
         array = interpolate_role_actors(roles, actors)
-        self.assertTrue(array[0].count(b'Nick (Author)') == 2)
-        self.assertTrue(array[2].count(b'Nick (Printer)') == 1)
-        self.assertTrue(array[4].count(b'Nick (Censor)') == 1)
+        self.assertTrue(array[0].count('Nick (Author)') == 2)
+        self.assertTrue(array[2].count('Nick (Printer)') == 1)
+        self.assertTrue(array[4].count('Nick (Censor)') == 1)
 
     def test_snake_to_camel(self):
         self.assertEqual(snake_to_camel(''), '')

--- a/footprints/main/tests/test_views.py
+++ b/footprints/main/tests/test_views.py
@@ -254,14 +254,12 @@ class ExportFootprintSearchTest(TestCase):
                    'Evidence Call Number,Evidence Details,')
 
         for r in Role.objects.for_footprint():
-            role = 'Footprint Role ' + smart_text(r.name).encode('utf-8')\
-                     + ' Actor'
+            role = 'Footprint Role ' + smart_text(r.name) + ' Actor'
             headers += role + ','
             headers += (role + ' VIAF Number,')
 
         for r in Role.objects.for_imprint():
-            role = 'Imprint Role: ' + smart_text(r.name).encode('utf-8')\
-                     + ' Actor'
+            role = 'Imprint Role: ' + smart_text(r.name) + ' Actor'
             headers += role + ','
             headers += (role + ' VIAF Number,')
 
@@ -284,9 +282,9 @@ class ExportFootprintSearchTest(TestCase):
                   for a in self.footprint2.book_copy.imprint.actor.all()]
         actors = '; '.join(actors)
 
-        row1 = [b'Empty Footprint', b'None', b'None', b'', b'None', b'None',
-                b'', b'None', self.footprint1.created_at.strftime('%m/%d/%Y'),
-                0, b'None', b'', b'', b'', b'', b'', b'None', b'None']
+        row1 = ['Empty Footprint', 'None', 'None', '', 'None', 'None',
+                '', 'None', self.footprint1.created_at.strftime('%m/%d/%Y'),
+                0, 'None', '', '', '', '', '', 'None', 'None']
 
         row1 += interpolate_role_actors(Role.objects.all().for_footprint(),
                                         self.footprint1.actors())
@@ -296,24 +294,24 @@ class ExportFootprintSearchTest(TestCase):
             self.footprint1.book_copy.imprint.actor.all())
 
         work = self.footprint2.book_copy.imprint.work
-        row2 = [b'Odyssey',  # Footprint Title
-                b'c. 1984',  # Footprint Date
-                b'Cracow, Poland',  # Footprint Location
-                o.encode(),  # Footprint Owners
-                work.title.encode(),  # Written Work Title
-                b'The Odyssey, Edition 1',  # Imprint Display Title
-                p.encode(),  # Imprint Printers
-                b'c. 1984',  # Imprint Creation Date
+        row2 = ['Odyssey',  # Footprint Title
+                'c. 1984',  # Footprint Date
+                'Cracow, Poland',  # Footprint Location
+                o,  # Footprint Owners
+                work.title,  # Written Work Title
+                'The Odyssey, Edition 1',  # Imprint Display Title
+                p,  # Imprint Printers
+                'c. 1984',  # Imprint Creation Date
                 self.footprint2.created_at.strftime('%m/%d/%Y'),
                 90,  # Footprint Percent Complete
-                b'None',
-                actors.encode(),  # Imprint Actor and Role
-                b'',  # Imprint BHB
-                b'',  # Imprint OCLC Number
-                b'Medium',  # Evidence Type
-                b'Provenance',  # Evidence Location
-                b'call number',  # Evidence Call Number
-                b'lorem ipsum']
+                'None',
+                actors,  # Imprint Actor and Role
+                '',  # Imprint BHB
+                '',  # Imprint OCLC Number
+                'Medium',  # Evidence Type
+                'Provenance',  # Evidence Location
+                'call number',  # Evidence Call Number
+                'lorem ipsum']
 
         # Footprint Actors
         row2 += interpolate_role_actors(Role.objects.all().for_footprint(),

--- a/footprints/main/utils.py
+++ b/footprints/main/utils.py
@@ -38,8 +38,8 @@ def interpolate_role_actors(roles, actors):
     separated by a semicolon.'''
     array = []
     for r in roles:
-        actor_string = b''
-        viaf_string = b''
+        actor_string = ''
+        viaf_string = ''
         # for each actor
         for a in actors:
             # if the actor matches that role
@@ -48,21 +48,21 @@ def interpolate_role_actors(roles, actors):
                 # iteration, add the actor, else append a semicolon and the
                 # actor to the end of the actor string
                 if not actor_string:
-                    actor_string = smart_text(a).encode('utf-8')
+                    actor_string = smart_text(a)
                 else:
-                    actor_string = b'; '.join(
-                        [actor_string, smart_text(a).encode('utf-8')])
+                    actor_string = '; '.join(
+                        [actor_string, smart_text(a)])
 
                 # If the VIAF String is empty, as it would be on the first
                 # iteration, add the VIAF number. Else append a semicolon
                 # and the VIAF number at the end of the string
                 if not viaf_string:
                     viaf_string = \
-                        a.person.get_viaf_number().encode('utf-8')
+                        a.person.get_viaf_number()
                 else:
-                    viaf_string = b'; '.join(
+                    viaf_string = '; '.join(
                         [viaf_string,
-                         a.person.get_viaf_number().encode('utf-8')])
+                         a.person.get_viaf_number()])
 
         array.append(actor_string)
         array.append(viaf_string)

--- a/footprints/main/views.py
+++ b/footprints/main/views.py
@@ -279,33 +279,31 @@ class ExportFootprintSearch(BaseSearchView):
 
             row = []
             # Footprint title
-            row.append(smart_text(o.title).encode('utf-8'))
+            row.append(o.title)
             # Footprint date
-            row.append(smart_text(o.associated_date).encode('utf-8'))
+            row.append(smart_text(o.associated_date))
 
             # Footprint location
-            row.append(smart_text(o.place).encode('utf-8'))
+            row.append(smart_text(o.place))
 
             # owners
             a = [owner.display_name() for owner in o.owners()]
-            row.append(smart_text('; '.join(a)).encode('utf-8'))
+            row.append(smart_text('; '.join(a)))
 
             # Written work title
-            row.append(smart_text(o.book_copy.imprint.work.title)
-                       .encode('utf-8'))
+            row.append(smart_text(o.book_copy.imprint.work.title))
 
             # Imprint display_title
-            a = smart_text(o.book_copy.imprint.display_title()).encode('utf-8')
+            a = smart_text(o.book_copy.imprint.display_title())
             row.append(a)
 
             # Imprint Printers
             a = [p.display_name()
                  for p in o.book_copy.imprint.printers()]
-            row.append(smart_text('; '.join(a)).encode('utf-8'))
+            row.append(smart_text('; '.join(a)))
 
             # Imprint publication date
-            row.append(smart_text(o.book_copy.imprint.publication_date)
-                       .encode('utf-8'))
+            row.append(smart_text(o.book_copy.imprint.publication_date))
 
             # Imprint created at date
             row.append(o.created_at.strftime('%m/%d/%Y'))
@@ -316,41 +314,41 @@ class ExportFootprintSearch(BaseSearchView):
             # Literary work LOC
             loc_id = o.book_copy.imprint.work\
                 .get_library_of_congress_identifier()
-            loc_id = smart_text(loc_id).encode('utf-8')
+            loc_id = smart_text(loc_id)
             row.append(loc_id)
 
             # Imprint actor
-            actors = [smart_text(p).encode('utf-8') for p
+            actors = [smart_text(p) for p
                       in o.book_copy.imprint.actor.all()]
-            row.append(b'; '.join(actors))
+            row.append('; '.join(actors))
 
             # Imprint BHB
             if o.book_copy.imprint.has_bhb_number():
                 row.append(smart_text(o.book_copy
                                        .imprint.get_bhb_number()
-                                       .identifier).encode('utf-8'))
+                                       .identifier))
             else:
-                row.append(b'')
+                row.append('')
 
             # Imprint OCLC #
             if o.book_copy.imprint.has_oclc_number():
                 row.append(smart_text(o.book_copy
                                        .imprint.get_oclc_number()
-                                       .identifier).encode('utf-8'))
+                                       .identifier))
             else:
-                row.append(b'')
+                row.append('')
 
             # Evidence type
-            row.append(smart_text(o.medium).encode('utf-8'))
+            row.append(smart_text(o.medium))
 
             # Evidence location
-            row.append(smart_text(o.provenance).encode('utf-8'))
+            row.append(smart_text(o.provenance))
 
             # Evidence source
-            row.append(smart_text(o.call_number).encode('utf-8'))
+            row.append(smart_text(o.call_number))
 
             # Evidence details
-            row.append(smart_text(o.notes).encode('utf-8'))
+            row.append(smart_text(o.notes))
 
             # Footprint Actors
             row.extend(self.get_footprint_actors_string(o))


### PR DESCRIPTION
By default, python3 encodes to utf-8. Remove all the special handling we needed for python2 to simplify the code and ensure the proper encoding on data export.