### PR TITLE
Pathmapper: Handle invalid parameters

### DIFF
--- a/footprints/pathmapper/forms.py
+++ b/footprints/pathmapper/forms.py
@@ -49,7 +49,12 @@ class ModelSearchFormEx(ModelSearchForm):
     def clean_year(self, fieldname):
         year = self.cleaned_data.get(fieldname, '')
 
-        if not isinstance(year, int):
+        if isinstance(year, str):
+            try:
+                self.cleaned_data[fieldname] = int(year)
+            except ValueError:
+                return
+        elif not isinstance(year, int):
             return
 
         now = datetime.now()

--- a/footprints/pathmapper/tests/test_forms.py
+++ b/footprints/pathmapper/tests/test_forms.py
@@ -157,6 +157,24 @@ class ModelSearchFormExTest(TestCase):
         sqs = form.search()
         self.assertEqual(sqs.count(), 0)
 
+    def test_form_clean_errors_string_date(self):
+        form = ModelSearchFormEx()
+        form._errors = {}
+        form.cleaned_data = {}
+        form.data = {
+            'q': '',
+            'footprintStart': '0',
+            'footprintEnd': 2020,
+            'footprintRange': 'false',
+            'pubStart': None,
+            'pubEnd': None,
+            'pubRange': False
+        }
+
+        form.clean()
+        self.assertTrue(form._errors['footprintStart'],
+                        ['Year must be greater than 1000'])
+
     def test_form_clean_errors_future_date(self):
         form = ModelSearchFormEx()
         form._errors = {}


### PR DESCRIPTION
The start year came through as a string representing a numberic value. Handle this corner case.