### PR TITLE
Limit all exports to less than 5,000 records 

### DIFF
--- a/footprints/main/views.py
+++ b/footprints/main/views.py
@@ -11,7 +11,8 @@ from django.contrib.syndication.views import Feed
 from django.core.mail import send_mail
 from django.db.models.fields import FieldDoesNotExist
 from django.db.models.fields.related import ManyToManyField
-from django.http.response import HttpResponseRedirect, StreamingHttpResponse
+from django.http.response import HttpResponseRedirect, StreamingHttpResponse, \
+    HttpResponseBadRequest
 from django.shortcuts import get_object_or_404
 from django.template import loader
 from django.urls.base import reverse
@@ -366,10 +367,10 @@ class ExportFootprintSearch(BaseSearchView):
         form_class = self.get_form_class()
         form = self.get_form(form_class)
 
-        if form.is_valid():
-            queryset = form.search()
-        else:
-            queryset = self.get_queryset()
+        if not form.is_valid():
+            return HttpResponseBadRequest('')
+
+        queryset = form.search()
 
         rows = self.get_rows(queryset)
         pseudo_buffer = Echo()

--- a/footprints/templates/search/search.html
+++ b/footprints/templates/search/search.html
@@ -381,12 +381,10 @@
             <div class="total-results-count">
                 {{paginator.count}} footprints
             </div>
-            {% if object_list|length > 0 %}
-                {% if search_criteria or not request.user.is_anonymous %}
-                    <button class="btn btn-white btn-sm btn-export" type="button">
-                        <span class="glyphicon glyphicon-download-alt"></span> Export
-                    </button>
-                {% endif %}
+            {% if object_list|length > 0 and search_criteria %}
+                <button class="btn btn-white btn-sm btn-export" type="button">
+                    <span class="glyphicon glyphicon-download-alt"></span> Export
+                </button>
             {% endif %}
         </div>
         <div class="col-xs-6">

--- a/footprints/templates/search/search.html
+++ b/footprints/templates/search/search.html
@@ -381,7 +381,7 @@
             <div class="total-results-count">
                 {{paginator.count}} footprints
             </div>
-            {% if object_list|length > 0 and search_criteria %}
+            {% if search_criteria and paginator.count < 5000 and paginator.count > 0 %}
                 <button class="btn btn-white btn-sm btn-export" type="button">
                     <span class="glyphicon glyphicon-download-alt"></span> Export
                 </button>


### PR DESCRIPTION
We're planning to keep a full .csv export in Academic Commons. The full exports are just too intensive for a synchronous delivery.