### PR TITLE
Pathmapper: Rethink footprint date queries

### DIFF
--- a/footprints/pathmapper/forms.py
+++ b/footprints/pathmapper/forms.py
@@ -116,19 +116,19 @@ class ModelSearchFormEx(ModelSearchForm):
 
         if ranged:
             if start_year:
-                start_from = self.format_solr_date(date(start_year, 1, 1))
+                start = self.format_solr_date(date(start_year, 1, 1))
             else:
-                start_from = '*'
+                start = '*'
 
             if end_year:
-                end_from = self.format_solr_date(date(end_year, 12, 31))
+                end = self.format_solr_date(date(end_year, 12, 31))
             else:
-                end_from = '*'
+                end = '*'
         else:
-            start_from = self.format_solr_date(date(start_year, 1, 1))
-            end_from = self.format_solr_date(date(start_year, 12, 31))
+            start = self.format_solr_date(date(start_year, 1, 1))
+            end = self.format_solr_date(date(start_year, 12, 31))
 
-        return q.format(fld, start_from, end_from, start_from, end_from)
+        return q.format(fld, start, end, start, end)
 
     def filter_by_footprint_year(self, fld, sqs):
         start_year = self.cleaned_data.get('footprint_start')

--- a/footprints/pathmapper/tests/test_forms.py
+++ b/footprints/pathmapper/tests/test_forms.py
@@ -73,6 +73,43 @@ class ModelSearchFormExTest(TestCase):
         self.assertEqual(
             kwargs['footprint_end_date__lte'], date(1886, 12, 31))
 
+    def test_format_footprint_year_query(self):
+        form = ModelSearchFormEx()
+        fld = 'book_copy_id'
+        q = form.format_footprint_year_query(fld, 1556, None, False)
+        self.assertEquals(
+            q,
+            '{!join from=book_copy_id to=django_id}'
+            'django_ct:"main.footprint" AND footprint_start_date:'
+            '[1556-01-01T00:00:00Z TO 1556-12-31T00:00:00Z]'
+            ' AND footprint_end_date:[1556-01-01T00:00:00Z TO '
+            '1556-12-31T00:00:00Z]')
+
+        q = form.format_footprint_year_query(fld, 1556, 1689, True)
+        self.assertEquals(
+            q,
+            '{!join from=book_copy_id to=django_id}'
+            'django_ct:"main.footprint" AND footprint_start_date:'
+            '[1556-01-01T00:00:00Z TO 1689-12-31T00:00:00Z]'
+            ' AND footprint_end_date:[1556-01-01T00:00:00Z TO '
+            '1689-12-31T00:00:00Z]')
+
+        q = form.format_footprint_year_query(fld, 1556, None, True)
+        self.assertEquals(
+            q,
+            '{!join from=book_copy_id to=django_id}'
+            'django_ct:"main.footprint" AND footprint_start_date:'
+            '[1556-01-01T00:00:00Z TO *]'
+            ' AND footprint_end_date:[1556-01-01T00:00:00Z TO *]')
+
+        q = form.format_footprint_year_query(fld, None, 1556, True)
+        self.assertEquals(
+            q,
+            '{!join from=book_copy_id to=django_id}'
+            'django_ct:"main.footprint" AND footprint_start_date:'
+            '[* TO 1556-12-31T00:00:00Z]'
+            ' AND footprint_end_date:[* TO 1556-12-31T00:00:00Z]')
+
     def test_handle_pub_year(self):
         form = ModelSearchFormEx()
         form.cleaned_data = {
@@ -294,9 +331,6 @@ class BookCopySearchFormTest(TestCase):
         self.assertEqual(kwargs['imprint_location'], 14)
         self.assertEqual(kwargs['footprint_location'], 15)
         self.assertEqual(args[0], Q(actor_exact__in=[16]))
-        self.assertEqual(kwargs['footprint_start_date__gte'], date(1910, 1, 1))
-        self.assertEqual(
-            kwargs['footprint_end_date__lte'], date(1940, 12, 31))
         self.assertEqual(kwargs['pub_start_date__gte'], date(1800, 1, 1))
         self.assertEqual(
             kwargs['pub_start_date__lte'], date(1800, 12, 31))
@@ -316,9 +350,6 @@ class ImprintSearchFormTest(TestCase):
         self.assertEqual(kwargs['imprint_location'], 14)
         self.assertEqual(kwargs['footprint_location'], 15)
         self.assertEqual(args[0], Q(actor_exact__in=[16]))
-        self.assertEqual(kwargs['footprint_start_date__gte'], date(1910, 1, 1))
-        self.assertEqual(
-            kwargs['footprint_end_date__lte'], date(1940, 12, 31))
         self.assertEqual(kwargs['pub_start_date__gte'], date(1800, 1, 1))
         self.assertEqual(
             kwargs['pub_start_date__lte'], date(1800, 12, 31))
@@ -338,9 +369,6 @@ class WrittenWorkSearchFormTest(TestCase):
         self.assertEqual(kwargs['imprint_location'], 14)
         self.assertEqual(kwargs['footprint_location'], 15)
         self.assertEqual(args[0], Q(actor_exact__in=[16]))
-        self.assertEqual(kwargs['footprint_start_date__gte'], date(1910, 1, 1))
-        self.assertEqual(
-            kwargs['footprint_end_date__lte'], date(1940, 12, 31))
         self.assertEqual(kwargs['pub_start_date__gte'], date(1800, 1, 1))
         self.assertEqual(
             kwargs['pub_start_date__lte'], date(1800, 12, 31))
@@ -352,19 +380,14 @@ class ActorSearchFormTest(TestCase):
         form = ActorSearchForm()
         form.cleaned_data = SAMPLE_CLEANED_DATA
 
-        args, kwargs = form.arguments()
-        self.assertEqual(args[0], Q(django_ct__in=['main.writtenwork',
-                                                   'main.footprint',
-                                                   'main.imprint']))
+        args, kwargs = form.arguments('main.writtenwork')
+        self.assertEqual(kwargs['django_ct'], 'main.writtenwork')
         self.assertFalse('content' in kwargs)
-        self.assertEqual(args[1], Q(actor_title_exact__contains='Foo'))
+        self.assertEqual(args[0], Q(actor_title_exact__contains='Foo'))
         self.assertEqual(kwargs['work_id'], 12)
         self.assertEqual(kwargs['imprint_id'], 13)
         self.assertEqual(kwargs['imprint_location'], 14)
         self.assertEqual(kwargs['footprint_location'], 15)
-        self.assertEqual(kwargs['footprint_start_date__gte'], date(1910, 1, 1))
-        self.assertEqual(
-            kwargs['footprint_end_date__lte'], date(1940, 12, 31))
         self.assertEqual(kwargs['pub_start_date__gte'], date(1800, 1, 1))
         self.assertEqual(
             kwargs['pub_start_date__lte'], date(1800, 12, 31))


### PR DESCRIPTION
The Footprints Pathmapper feature allows users to search for book copies across a range of criteria, including footprint date ranges. In an attempt to be efficient, each of the primary Footprints Solr documents -- WrittenWork, Imprint and Bookcopy -- has a composed date range for their set of footprints and publication dates. Researchers digging into the visualization are finding this approach far too abstract. And, in many instances, the results appear incorrect or confusing.

Using the example [ʻAḳedat Yitsḥaḳ](https://footprints.ctl.columbia.edu/writtenwork/67/) with the 1522, Sefer ʻAḳedat Yitsḥaḳ  imprint: The Solr core is stocked with three documents representing the three book copies:

* 67-1945-2104,  Footprint Start: 1556-03-18, Footprint End: 1556-03-18
* 67-1945-2281. Footprint Start: 1597-01-01, Footprint End: 1986-12-31
* 67-1945-2674, Footprint Start: 1500-01-01, Footprint End: 1993-12-31

Searching those abstracted ranges is useful, but does not allow the research to zero in on a more precise range. For example, they cannot ask the question, "Which book copies have footprints in 1613?"

To remedy this issue, I've updated the code to join a related model (WrittenWork, Imprint, BookCopy) to its footprint set, allowing a query directly against the footprint data. This allows the more precise search we are looking for by narrowing the initial search by the date range. Caution: This also introduces Solr specific syntax into the mix.

This exercise has left me with a lot of questions. First - does the same thing need to happen for publication date ranges? Second - is Solr really needed for these queries? Third - how can I mock Solr to allow for a good test suite on this code? Four - if we are sticking to Solr, is there a way to return to a more generic query syntax? More work to do.










