### PR TITLE
Remove path from test file - closes #2280

### DIFF
--- a/footprints/main/tests/factories.py
+++ b/footprints/main/tests/factories.py
@@ -1,4 +1,3 @@
-import os
 import random
 
 from django.contrib.auth.models import User, Group, Permission
@@ -14,7 +13,7 @@ from footprints.main.models import (
 from footprints.main.utils import string_to_point
 
 
-TEST_MEDIA_PATH = os.path.join(os.path.dirname(__file__), 'test.txt')
+TEST_MEDIA_PATH = 'test.txt'
 
 
 BATCH_PERMISSIONS = [


### PR DESCRIPTION
This recent CVE fix prevents pathnames in the files, causing this test
failure. https://github.com/django/django/commit/0b79eb36915d178aef5c6a7bbce71b1e76d376d3