### PR TITLE
Update carousel to favor width over height

### DIFF
--- a/media/css/main.css
+++ b/media/css/main.css
@@ -1412,8 +1412,8 @@ img.footicon {
 }
 
 #carousel-fullsize img {
-    height: 600px;
-    width: auto;
+    height: auto;
+    width: 100%;
     margin: 0 auto;
 }
 


### PR DESCRIPTION
As the carousel is constrained by width, allow the images to exist at 100% width and auto height. This should prevent distorted images.