### PR TITLE
Include person gender in footprint front end

### DIFF
--- a/footprints/main/models.py
+++ b/footprints/main/models.py
@@ -1,4 +1,6 @@
 from datetime import date
+from enum import Enum
+import json
 
 from audit_log.models.fields import LastUserField, CreatingUserField
 from django.contrib.gis.db.models.fields import PointField
@@ -484,15 +486,20 @@ class PersonManager(models.Manager):
         return person
 
 
-FEMALE = 'f'
-MALE = 'm'
-UNASSIGNED = 'u'
+class GENDER_CHOICES_ENUM(Enum):
+    FEMALE = 'f'
+    MALE = 'm'
+    UNASSIGNED = 'u'
 
-GENDER_CHOICES = (
-    (FEMALE, 'Female'),
-    (MALE, 'Male'),
-    (UNASSIGNED, 'Unassigned')
-)
+
+gender_choices_dict = {
+    gender.name: gender.value
+    for gender in GENDER_CHOICES_ENUM
+}
+GENDER_CHOICES_JSON = json.dumps(gender_choices_dict)
+GENDER_CHOICES = [
+    (gender.value, gender.name.capitalize()) for gender in GENDER_CHOICES_ENUM
+]
 
 
 class Person(models.Model):
@@ -509,8 +516,8 @@ class Person(models.Model):
                                       related_name="death_date",
                                       on_delete=models.CASCADE)
 
-    gender = models.CharField(
-        max_length=1, choices=GENDER_CHOICES, default=UNASSIGNED)
+    gender = models.CharField(max_length=1, choices=GENDER_CHOICES,
+                              default=GENDER_CHOICES_ENUM.UNASSIGNED.value)
 
     standardized_identifier = models.ForeignKey(StandardizedIdentification,
                                                 null=True, blank=True,

--- a/footprints/main/serializers.py
+++ b/footprints/main/serializers.py
@@ -91,7 +91,7 @@ class PersonSerializer(HyperlinkedModelSerializer):
 
     class Meta:
         model = Person
-        fields = ('id', 'name', 'birth_date', 'death_date',
+        fields = ('id', 'name', 'birth_date', 'death_date', 'gender',
                   'standardized_identifier')
 
 

--- a/footprints/main/views.py
+++ b/footprints/main/views.py
@@ -29,7 +29,7 @@ from footprints.main.models import (
     Footprint, Actor, Person, Role, WrittenWork, Language,
     Place, Imprint, BookCopy, StandardizedIdentification,
     StandardizedIdentificationType, ExtendedDate, MEDIUM_CHOICES,
-    work_actor_changed, CanonicalPlace)
+    work_actor_changed, CanonicalPlace, GENDER_CHOICES_JSON)
 from footprints.main.serializers import NameSerializer
 from footprints.main.templatetags.moderation import moderation_footprints
 from footprints.main.utils import interpolate_role_actors, string_to_point
@@ -104,6 +104,7 @@ class FootprintDetailView(DetailView):
         context['identifier_types'] = \
             StandardizedIdentificationType.objects.all().order_by('name')
         context['mediums'] = MEDIUM_CHOICES
+        context['gender_choices_json'] = GENDER_CHOICES_JSON
         context.update(self.permissions(self.request.user, self.get_object()))
         return context
 

--- a/footprints/templates/clientside/footprint.html
+++ b/footprints/templates/clientside/footprint.html
@@ -163,7 +163,13 @@
                         </a>
                     </span>
                 <% } %>
-                <span><%=actor[i].person.name%><% if (actor[i].alias) { %>  as <%=actor[i].alias%> <% } %></span> 
+                <span>
+                    <%=actor[i].person.name%>
+                    <% if (actor[i].alias) { %>  as <%=actor[i].alias%> <% } %>
+                    <% if (actor[i].person.gender != gender_choices.UNASSIGNED) { %>
+                        (<%=actor[i].person.gender%>) 
+                    <% } %>
+                </span> 
                 <div class="pull-right">
                     <% if (can_edit_footprint) { %>
                         <a href="javascript:void(0);" class="remove-related"

--- a/footprints/templates/clientside/footprint_book.html
+++ b/footprints/templates/clientside/footprint_book.html
@@ -41,7 +41,11 @@
                                 </span>
                             <% } %>
                             <span>
-                                <%=current_owner.person.name%><% if (current_owner.alias) { %>  as <%=current_owner.alias%> <% } %>
+                                <%=current_owner.person.name%>
+                                <% if (current_owner.alias) { %>  as <%=current_owner.alias%> <% } %>
+                                <% if (current_owner.person.gender != gender_choices.UNASSIGNED) { %>
+                                    (<%=current_owner.person.gender%>) 
+                                <% } %>
                             </span> 
                         </dd>
                     <% } %>
@@ -102,7 +106,11 @@
                         </span>
                     <% } %>
                     <span>
-                        <%=imprint.work.actor[i].person.name%><% if (imprint.work.actor[i].alias) { %>  as <%=imprint.work.actor[i].alias%> <% } %>
+                        <%=imprint.work.actor[i].person.name%>
+                        <% if (imprint.work.actor[i].alias) { %>  as <%=imprint.work.actor[i].alias%> <% } %>
+                        <% if (imprint.work.actor[i].person.gender != gender_choices.UNASSIGNED) { %>
+                            (<%=imprint.work.actor[i].person.gender%>) 
+                        <% } %>
                     </span> 
                     <div class="pull-right">
                         <% if (can_edit_work) { %>
@@ -272,7 +280,11 @@
                         </span>
                     <% } %>
                     <span>
-                        <%=imprint.actor[i].person.name%><% if (imprint.actor[i].alias) { %>  as <%=imprint.actor[i].alias%> <% } %>
+                        <%=imprint.actor[i].person.name%>
+                        <% if (imprint.actor[i].alias) { %>  as <%=imprint.actor[i].alias%> <% } %>
+                        <% if (imprint.actor[i].person.gender != gender_choices.UNASSIGNED) { %>
+                            (<%=imprint.actor[i].person.gender%>) 
+                        <% } %>
                     </span> 
                     <div class="pull-right">
                         <% if (can_edit_imprint) { %>

--- a/footprints/templates/main/footprint_detail.html
+++ b/footprints/templates/main/footprint_detail.html
@@ -149,6 +149,7 @@
                     all_mediums:  [{% for medium in mediums %}
                                    {value: '{{medium}}', text: "{{medium}}"}{% if not forloop.last %},{% endif %}
                                    {% endfor %}, {value: "Other", text: "Other"}],
+                    gender_choices: JSON.parse('{{ gender_choices_json | escapejs }}'),
                     can_edit_footprint: {% if can_edit_footprint %}true{% else %}false{% endif %},
                     can_edit_copy: {% if can_edit_copy %}true{% else %}false{% endif %},
                     can_edit_imprint: {% if can_edit_imprint %}true{% else %}false{% endif %},


### PR DESCRIPTION
- Add gender of persons listed on the footprint details page.
- The gender is shown as one letter in parenthesis (m) or (f) following the person's name (and alias), such as 'Aaron Priven (m)'.
- The gender is not shown if the person's gender is undefined.