### PR TITLE
Revert "Bump sentry-sdk from 1.32.0 to 1.33.1"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -79,7 +79,7 @@ django-paging==0.2.5
 django-appconf==1.0.5
 django-statsd-mozilla==0.4.0
 raven==6.10.0
-sentry-sdk==1.33.1
+sentry-sdk==1.32.0
 django-bootstrap-form==3.4
 django-debug-toolbar==4.2.0
 django-waffle==4.0.0


### PR DESCRIPTION
Reverts ccnmtl/footprints#2989