### PR TITLE
sentry-sdk: enable django extra

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -79,7 +79,7 @@ django-paging==0.2.5
 django-appconf==1.0.5
 django-statsd-mozilla==0.4.0
 raven==6.10.0
-sentry-sdk==2.10.0
+sentry-sdk[django]==2.10.0
 django-bootstrap-form==3.4
 django-debug-toolbar==4.4.1
 django-waffle==4.1.0


### PR DESCRIPTION
This is the recommended way to use sentry-sdk when using the DjangoIntegration feature which we use in ctlsettings: https://docs.sentry.io/platforms/python/integrations/django/

In practice, I don't think this actually does much aside from ensuring through pip that django is installed, via the package's extras_require configuration in setup.py:
https://github.com/getsentry/sentry-python/blob/master/setup.py#L56