### PR TITLE
Remove db info from settings_stage

### DIFF
--- a/footprints/settings_staging.py
+++ b/footprints/settings_staging.py
@@ -13,18 +13,6 @@ locals().update(
     ))
 
 
-DATABASES = {
-    'default': {
-        'ENGINE': 'django.contrib.gis.db.backends.postgis',
-        'NAME': 'footprints',
-        'HOST': '',
-        'PORT': 6432,
-        'USER': '',
-        'PASSWORD': '',
-    }
-}
-
-
 try:
     from footprints.local_settings import *  # noqa F403 F405
 except ImportError:


### PR DESCRIPTION
This is now in salt_state/apps/footprints/local_settings.py where I have RDS Proxy info set for staging.