### PR TITLE
Migrate Footprint & Imprint Detail Maps to Leaflet/OSM/Stadia

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -27,6 +27,7 @@ export default [...compat.extends("eslint:recommended"),
             Promise: true,
             MarkerClusterer: true,
             Highcharts: true,
+            L: true
         },
 
         ecmaVersion: 9,

--- a/footprints/settings_shared.py
+++ b/footprints/settings_shared.py
@@ -171,8 +171,12 @@ SPECTACULAR_SETTINGS = {
 
 GOOGLE_MAPS_REVERSE_GEOCODE = \
     'https://maps.googleapis.com/maps/api/geocode/json?address={},{}'
+
 TILE_SERVER_ATTRIBUTION = \
-    '&copy; OpenStreetMap contributors &copy; Stadia Maps'
+    '&copy; <a href="https://stadiamaps.com/" target="_blank">Stadia Maps</a>&nbsp;|&nbsp;' \
+    '&copy; <a href="https://openmaptiles.org/" target="_blank">OpenMapTiles</a>&nbsp;|&nbsp;' \
+    '&copy; <a href="https://www.openstreetmap.org/copyright" target="_blank">OpenStreetMap</a>'
+
 TILE_SERVER_URL = \
     'https://tiles.stadiamaps.com/tiles/osm_bright/{z}/{x}/{y}.png'
 

--- a/footprints/templates/base-new.html
+++ b/footprints/templates/base-new.html
@@ -216,8 +216,9 @@
             staticUrl: '{{STATIC_URL}}',
             debug: {% if debug %}'true'{% else %}'false'{% endif %},
             mapKey: '{{settings.GOOGLE_MAP_API}}',
+            baseUrl: '//{{ request.get_host }}/',
             tileServer: {
-                attribution: '{{settings.TILE_SERVER_ATTRIBUTION}}',
+                attribution: '{{settings.TILE_SERVER_ATTRIBUTION|safe}}',
                 url: '{{settings.TILE_SERVER_URL}}'
             }
         };

--- a/footprints/templates/base.html
+++ b/footprints/templates/base.html
@@ -208,7 +208,7 @@
             baseUrl: '//{{ request.get_host }}/',
             geonamesKey: '{{settings.GEONAMES_KEY}}',
             tileServer: {
-                attribution: '{{settings.TILE_SERVER_ATTRIBUTION}}',
+                attribution: '{{settings.TILE_SERVER_ATTRIBUTION|safe}}',
                 url: '{{settings.TILE_SERVER_URL}}'
             }
         };

--- a/footprints/templates/main/writtenwork_detail.html
+++ b/footprints/templates/main/writtenwork_detail.html
@@ -355,12 +355,10 @@
                 <div class="imprint-map"></div>
                 <div class="imprint-map-key">
                     <div class="legend">
-                        <img src="https://chart.googleapis.com/chart?chst=d_map_pin_letter&chld=%E2%80%A2|5e98b7" alt-text="Imprint Icon"/>
-                            <span class="small">Imprint</span>
-                        <img src="https://chart.googleapis.com/chart?chst=d_map_pin_letter&chld=%E2%80%A2|ffa881" alt-text="Footprint Icon"/>
-                            <span class="small">Footprint</span>
-                        <img src="https://chart.googleapis.com/chart?chst=d_map_pin_letter&chld=%2B|ff6e2d" alt-text="Multiple Icon"/>
-                            <span class="small">Multiple</span>
+                        <img class="imprint-marker" alt-text="Imprint Icon"/>
+                            <span class="imprint-label">Imprint</span>
+                        <img class="footprint-marker" alt-text="Footprint Icon"/>
+                            <span class="imprint-label">Footprint</span>
                     </div>
                 </div>
             </div>

--- a/media/css/main.css
+++ b/media/css/main.css
@@ -1675,10 +1675,27 @@ body.affix-container {
     padding: 5px 5px;
 }
 
-.object-detail .imprint-map-container .imprint-map-key .legend img {
-    height: 18px;
-    width: auto;
-    margin-left: 10px;
+.object-detail .imprint-map-container .imprint-map-key .legend .imprint-label {
+    float: left;
+}
+
+.object-detail .imprint-map-container .imprint-map-key .legend .imprint-marker,
+.object-detail .imprint-map-container .imprint-map-key .legend .footprint-marker {
+    width: 16px;
+    height: 16px;
+    border-radius: 50%;
+    border: 2px solid white;
+    box-shadow: 0 0 2px rgba(0,0,0,0.5);
+    margin: 2px 5px 0 10px;
+    float: left;
+}
+
+.object-detail .imprint-map-container .imprint-map-key .legend .imprint-marker {
+    background-color: #5e98b7;
+}
+
+.object-detail .imprint-map-container .imprint-map-key .legend .footprint-marker {
+    background-color: #ffa881;
 }
 
 .object-detail .footprint-map {

--- a/media/js/app/footprint-detail.js
+++ b/media/js/app/footprint-detail.js
@@ -35,14 +35,16 @@
                         zoom: 10,
                         dragging: false,
                         scrollWheelZoom: false,
-                        zoomControl: true
+                        zoomControl: false,
+                        doubleClickZoom: false,
+                        touchZoom: false,
+                        boxZoom: false,
                     }).setView(latlng, 10);
 
                     // Stadia tile layer
                     L.tileLayer(
                         Footprints.tileServer.url,
                         {
-                            maxZoom: 20,
                             attribution: Footprints.tileServer.attribution
                         }
                     ).addTo(this.map);

--- a/media/js/app/footprint-detail.js
+++ b/media/js/app/footprint-detail.js
@@ -21,38 +21,36 @@
             }
             return ctx;
         },
-        mapOptions: {
-            zoom: 10,
-            draggable: false,
-            scrollwheel: false,
-            mapTypeId: google.maps.MapTypeId.ROADMAP,
-            zoomControl: true,
-            zoomControlOptions: {
-                style: google.maps.ZoomControlStyle.SMALL,
-                position: google.maps.ControlPosition.RIGHT_BOTTOM
-            },
-            mapTypeControl: false,
-            streetViewControl: false,
-            fullscreenControl: false,
-            controlSize: 28
-        },
         initializeMap: function() {
-            // Initialize display map
             this.mapElt = jQuery(this.el).find('.footprint-map')[0];
             if (this.mapElt) {
                 var lat = jQuery(this.mapElt).data('latitude');
                 var lng = jQuery(this.mapElt).data('longitude');
-                if (lat && lng) {
-                    var latlng = new google.maps.LatLng(lat, lng);
-                    this.mapOptions.center = latlng;
-                    this.map = new google.maps
-                        .Map(this.mapElt, this.mapOptions);
 
-                    this.marker = new google.maps.Marker({
-                        position: latlng,
-                        map: this.map,
-                        title: jQuery(this.mapElt).data('title')
-                    });
+                if (lat && lng) {
+                    var latlng = [lat, lng];
+
+                    // Create map
+                    this.map = L.map(this.mapElt, {
+                        zoom: 10,
+                        dragging: false,
+                        scrollWheelZoom: false,
+                        zoomControl: true
+                    }).setView(latlng, 10);
+
+                    // Stadia tile layer
+                    L.tileLayer(
+                        Footprints.tileServer.url,
+                        {
+                            maxZoom: 20,
+                            attribution: Footprints.tileServer.attribution
+                        }
+                    ).addTo(this.map);
+
+                    // Marker
+                    this.marker = L.marker(latlng)
+                        .addTo(this.map)
+                        .bindPopup(jQuery(this.mapElt).data('title') || '');
                 }
             }
         },

--- a/media/js/app/footprint-detail.js
+++ b/media/js/app/footprint-detail.js
@@ -30,7 +30,6 @@
                 if (lat && lng) {
                     var latlng = [lat, lng];
 
-                    // Create map
                     this.map = L.map(this.mapElt, {
                         zoom: 10,
                         dragging: false,
@@ -41,7 +40,6 @@
                         boxZoom: false,
                     }).setView(latlng, 10);
 
-                    // Stadia tile layer
                     L.tileLayer(
                         Footprints.tileServer.url,
                         {
@@ -49,7 +47,6 @@
                         }
                     ).addTo(this.map);
 
-                    // Marker
                     this.marker = L.marker(latlng)
                         .addTo(this.map)
                         .bindPopup(jQuery(this.mapElt).data('title') || '');

--- a/media/js/app/imprint-detail.js
+++ b/media/js/app/imprint-detail.js
@@ -66,7 +66,7 @@
         },
         iconWithColor: function(color, multiple) {
             return L.divIcon({
-                className: "custom-marker",
+                className: 'custom-marker',
                 html: `
                             <div style="
                                 background-color: ${color};

--- a/media/js/app/imprint-detail.js
+++ b/media/js/app/imprint-detail.js
@@ -102,7 +102,9 @@
                 ).addTo(this.map);
 
                 this.bounds = L.latLngBounds();
-                this.clusterGroup = L.markerClusterGroup({ spiderfyOnMaxZoom: true });
+                this.clusterGroup = L.markerClusterGroup({
+                    spiderfyOnMaxZoom: true
+                });
                 this.map.addLayer(this.clusterGroup);
 
                 this.markers = {};
@@ -235,12 +237,12 @@
 
             var bounds = L.latLngBounds();
             for (var key in this.markers) {
-              if (Object.prototype.hasOwnProperty.call(this.markers, key)) {
-                var mk = this.markers[key].marker;
-                if (subset.indexOf(key) > -1) {
-                  bounds.extend(mk.getLatLng());
+                if (Object.prototype.hasOwnProperty.call(this.markers, key)) {
+                    var mk = this.markers[key].marker;
+                    if (subset.indexOf(key) > -1) {
+                        bounds.extend(mk.getLatLng());
+                    }
                 }
-              }
             }
 
             if (subset.length < 1) {
@@ -253,9 +255,9 @@
                 this.$el.find('.empty-map-message').hide();
                 this.activeBounds = bounds;
                 this.popup = L.popup()
-                  .setLatLng(this.markers[highlight].marker.getLatLng())
-                  .setContent(this.markers[highlight].content)
-                  .openOn(this.map);
+                    .setLatLng(this.markers[highlight].marker.getLatLng())
+                    .setContent(this.markers[highlight].content)
+                    .openOn(this.map);
             }
         },
         inView: function($elt) {

--- a/media/js/app/imprint-detail.js
+++ b/media/js/app/imprint-detail.js
@@ -1,5 +1,3 @@
-/* global OverlappingMarkerSpiderfier */
-
 (function() {
     window.ImprintView = Backbone.View.extend({
         events: {
@@ -10,17 +8,16 @@
             'click .share-link': 'onShareLink'
         },
         initialize: function(options) {
-            _.bindAll(this, 'initializeMap', 'attachInfoWindow', 'resize',
+            _.bindAll(this, 'initializeMap', 'resize',
                 'onClickBookCopy', 'onClickFootprint', 'onClickImprint',
-                'onClickWork', 'updateMarkerIcons', 'syncMap',
+                'onClickMarker', 'onClickWork', 'syncMap',
                 'onShareLink', 'clearState', 'setState',
                 'addHistory', 'popHistory');
 
             this.urlBase = options.urlBase;
 
-            this.footprintIcon = this.iconWithColor('ffa881');
-            this.imprintIcon = this.iconWithColor('5e98b7');
-            this.spiderIcon = this.iconWithColor('ff6e2d', true);
+            this.footprintIcon = this.iconWithColor('#ffa881');
+            this.imprintIcon = this.iconWithColor('#5e98b7');
 
             this.shareTemplate =
                 _.template(jQuery(options.shareTemplate).html());
@@ -33,35 +30,6 @@
             this.initializeMap(options);
             jQuery(this.el).find('[data-toggle="tooltip"]').tooltip();
         },
-        mapOptions: {
-            zoom: 10,
-            maxZoom: 10,
-            draggable: true,
-            scrollwheel: false,
-            navigationControl: false,
-            mapTypeControl: false,
-            scaleControl: false,
-            mapTypeId: google.maps.MapTypeId.ROADMAP,
-            zoomControl: true,
-            zoomControlOptions: {
-                style: google.maps.ZoomControlStyle.SMALL,
-                position: google.maps.ControlPosition.RIGHT_BOTTOM
-            },
-            streetViewControl: false
-        },
-        updateMarkerIcons: function() {
-            for (var key in this.markers) {
-                if (Object.prototype.hasOwnProperty.call(this.markers, key)) {
-                    var icon = this.getIcon(this.markers[key].marker.dataId);
-                    this.markers[key].marker.setIcon(icon);
-                }
-            }
-
-            var markers = this.spiderfier.markersNearAnyOtherMarker();
-            markers.forEach((m) => {
-                m.setIcon(this.spiderIcon);
-            });
-        },
         scrollToItem: function($elt) {
             var eltTop = $elt.offset().top - 150;
             var mapTop = jQuery('.foot').offset().top -
@@ -70,79 +38,6 @@
             jQuery('html, body').animate({
                 scrollTop: Math.min(eltTop, mapTop) + 'px'
             }, 900);
-        },
-        attachInfoWindow: function(infowindow, map, marker, content) {
-            var self = this;
-
-            this.spiderfier.addListener('click', function(marker, event) {
-                infowindow.setContent(marker.desc);
-                infowindow.open(map, marker);
-
-                var q = '[data-map-id="' + marker.dataId + '"]';
-                var $elt = self.$el.find(q).first();
-                jQuery(self.el).find('.infocus').removeClass('infocus');
-                self.setState(
-                    $elt.data('imprint-id'),
-                    $elt.data('copy-id'),
-                    $elt.data('footprint-id'),
-                    false /* sync map */);
-            });
-
-            this.spiderfier.addListener('spiderfy', function(markers) {
-                markers.forEach(function(m) {
-                    m.setIcon(self.getIcon(m.dataId));
-                });
-
-                infowindow.close();
-            });
-
-            this.spiderfier.addListener('unspiderfy', function(markers) {
-                markers.forEach(function(m) {
-                    m.setIcon(self.spiderIcon);
-                });
-            });
-
-            google.maps.event.addListener(map, 'click', function() {
-                infowindow.close();
-            });
-
-            // *
-            // http://en.marnoto.com/2014/09/
-            //     5-formas-de-personalizar-infowindow.html
-            // START INFOWINDOW CUSTOMIZE.
-            // The google.maps.event.addListener() event expects
-            // the creation of the infowindow HTML structure 'domready'
-            // and before the opening of the infowindow,
-            // defined styles are applied.
-            // *
-            google.maps.event.addListener(infowindow, 'domready', function() {
-                // Reference to the DIV that wraps the bottom of infowindow
-                var $iwOuter = jQuery('.gm-style-iw');
-
-                /* Since this div is in a position prior to .gm-div style-iw.
-                 * We use jQuery and create a iwBackground variable,
-                 * and took advantage of the existing reference .gm-style-iw
-                 * for the previous div with .prev().
-                */
-                var iwBackground = $iwOuter.prev();
-
-                // Removes background shadow DIV
-                iwBackground.children(':nth-child(2)')
-                    .css({'display': 'none'});
-
-                // Removes white background DIV
-                iwBackground.children(':nth-child(4)')
-                    .css({'display': 'none'});
-
-                // Changes the desired tail shadow color.
-                iwBackground.children(':nth-child(3)')
-                    .find('div').children()
-                    .css({'z-index': '1'});
-
-                // Reference to the div that groups the close button elements.
-                var iwCloseBtn = $iwOuter.next();
-                iwCloseBtn.css({top: '22px', right: '57px'});
-            });
         },
         getVisibleContentHeight: function() {
             // the more standards compliant browsers
@@ -170,92 +65,89 @@
                 this.footprintIcon : this.imprintIcon;
         },
         iconWithColor: function(color, multiple) {
-            var c = multiple ? '%2B' : '%E2%80%A2';
-            return 'https://chart.googleapis.com/chart?' +
-            'chst=d_map_pin_letter&chld=' + c + '|' + color;
+            return L.divIcon({
+                className: "custom-marker",
+                html: `
+                            <div style="
+                                background-color: ${color};
+                                width: 16px;
+                                height: 16px;
+                                border-radius: 50%;
+                                border: 2px solid white;
+                                box-shadow: 0 0 2px rgba(0,0,0,0.5);
+                            "></div>
+                        `,
+                iconSize: [16, 16],
+                iconAnchor: [8, 8],
+            });
         },
         initializeMap: function(options) {
             var self = this;
-
-            // compile lat/longs
             var markers = jQuery(this.el).find('.map-marker');
             if (markers.length > 0) {
-                this.infowindow = new google.maps.InfoWindow({
-                    maxWidth: 350
-                });
 
                 this.resize();
 
                 var mapElt = jQuery(this.el).find('.imprint-map')[0];
-                this.map = new google.maps.Map(mapElt, this.mapOptions);
 
-                this.bounds = new google.maps.LatLngBounds();
-                this.spiderfier = new OverlappingMarkerSpiderfier(this.map, {
-                    keepSpiderfied: true,
-                    markersWontMove: true,
-                    markersWontHide: false});
+                this.map = L.map(mapElt);
+
+                L.tileLayer(
+                    Footprints.tileServer.url,
+                    {
+                        maxZoom: 20,
+                        detectRetina: true,
+                        attribution: Footprints.tileServer.attribution
+                    }
+                ).addTo(this.map);
+
+                this.bounds = L.latLngBounds();
+                this.clusterGroup = L.markerClusterGroup({ spiderfyOnMaxZoom: true });
+                this.map.addLayer(this.clusterGroup);
 
                 this.markers = {};
-                for (var i=0; i < markers.length; i++) {
+
+                for (var i = 0; i < markers.length; i++) {
                     var m = markers[i];
                     var id = jQuery(m).data('related');
                     var lat = jQuery(m).data('latitude');
                     var lng = jQuery(m).data('longitude');
-                    var latlng = new google.maps.LatLng(lat, lng);
+                    var latlng = [lat, lng];
 
                     var content = jQuery(m).html();
 
-                    var marker = new google.maps.Marker({
-                        position: latlng,
-                        map: this.map,
+                    var marker = L.marker(latlng, {
                         icon: this.getIcon(id),
-                        desc: content,
                         dataId: id
                     });
+
+                    marker.bindPopup(content);
+
+                    marker.on('click', this.onClickMarker);
+
                     this.bounds.extend(latlng);
 
-                    this.markers[id] = {'marker': marker, 'content': content};
+                    this.markers[id] = {
+                        marker: marker,
+                        content: content
+                    };
+                    this.clusterGroup.addLayer(marker);
                 }
 
                 this.map.fitBounds(this.bounds);
-                this.attachInfoWindow(this.infowindow, this.map);
 
-                google.maps.event.addListener(this.map, 'idle', function() {
+                this.map.whenReady(function() {
                     if (!self.mapLoaded) {
                         self.mapLoaded = true;
-                        self.projection = self.map.getProjection();
+
                         self.setState(
                             options.state.imprint,
                             options.state.copy,
                             options.state.footprint,
-                            true);
-                        self.updateMarkerIcons();
+                            true
+                        );
                     }
                 });
-
-                google.maps.event.addListener(this.map, 'zoom_changed',
-                    function() {
-                        if (self.mapLoaded) {
-                            self.updateMarkerIcons();
-                        }
-                    }
-                );
-
-                google.maps.event.addListener(
-                    this.map,
-                    'bounds_changed',
-                    function() {
-                        // An infowindow opening throws off the fitBounds
-                        // logic. Call fitBounds again when necessary
-                        if (self.mapLoaded && self.activeBounds) {
-                            self.map.fitBounds(self.activeBounds);
-                            delete self.activeBounds;
-
-                            self.map.setZoom(self.map.getZoom() - 1);
-                        }
-                    }
-                );
-
                 jQuery('.imprint-map-container').affix({
                     offset: {
                         top: jQuery('.imprint-map-container').offset().top,
@@ -263,6 +155,22 @@
                     }
                 });
             }
+        },
+        onClickMarker: function(evt) {
+            var m = evt.target;
+
+            // find corresponding list item
+            var q = '[data-map-id="' + m.options.dataId + '"]';
+            var $elt = this.$el.find(q).first();
+
+            jQuery(this.el).find('.infocus').removeClass('infocus');
+
+            this.setState(
+                $elt.data('imprint-id'),
+                $elt.data('copy-id'),
+                $elt.data('footprint-id'),
+                false // sync map
+            );
         },
         onClickWork: function(evt) {
             this.clearState();
@@ -325,19 +233,14 @@
                 }
             }
 
-            var bounds = new google.maps.LatLngBounds();
+            var bounds = L.latLngBounds();
             for (var key in this.markers) {
-                if (Object.prototype.hasOwnProperty.call(this.markers, key)) {
-                    var mk = this.markers[key].marker;
-                    if (subset.indexOf(key) > -1) {
-                        mk.setVisible(true);
-                        bounds.extend(mk.getPosition());
-                        this.spiderfier.addMarker(mk);
-                    } else {
-                        mk.setVisible(false);
-                        this.spiderfier.removeMarker(mk);
-                    }
+              if (Object.prototype.hasOwnProperty.call(this.markers, key)) {
+                var mk = this.markers[key].marker;
+                if (subset.indexOf(key) > -1) {
+                  bounds.extend(mk.getLatLng());
                 }
+              }
             }
 
             if (subset.length < 1) {
@@ -349,9 +252,10 @@
             } else {
                 this.$el.find('.empty-map-message').hide();
                 this.activeBounds = bounds;
-                this.infowindow.setContent(this.markers[highlight].content);
-                this.infowindow.open(
-                    this.map, this.markers[highlight].marker);
+                this.popup = L.popup()
+                  .setLatLng(this.markers[highlight].marker.getLatLng())
+                  .setContent(this.markers[highlight].content)
+                  .openOn(this.map);
             }
         },
         inView: function($elt) {
@@ -388,8 +292,9 @@
             }
         },
         clearState: function() {
-            this.infowindow.close();
-            this.spiderfier.clearMarkers();
+            if (this.popup) {
+                this.map.closePopup(this.popup);
+            }
             jQuery(this.el).find('.infocus').removeClass('infocus');
         },
         popHistory: function(evt) {

--- a/media/js/xeditable/bootstrap-editable-place.js
+++ b/media/js/xeditable/bootstrap-editable-place.js
@@ -202,7 +202,8 @@ Place editable input.
 
             setTimeout(() => {
                 this.mapInstance.invalidateSize();
-                this.mapInstance.setView(this.defaultLatLng, this.mapOptions.zoom);
+                this.mapInstance.setView(
+                    this.defaultLatLng, this.mapOptions.zoom);
             }, 0);
         },
 
@@ -220,7 +221,7 @@ Place editable input.
 
            @method html2value(html)
         **/
-        html2value: function(html) { 
+        html2value: function(html) {
             return null;
         },
 
@@ -230,7 +231,7 @@ Place editable input.
 
            @method value2str(value)
         **/
-       value2str: function(value) {
+        value2str: function(value) {
             var str = '';
             if (value) {
                 var keys = Object.keys(value);
@@ -253,7 +254,7 @@ Place editable input.
               attribute. If you will always set value by javascript,
               no need to overwrite it
             */
-           return str;
+            return str;
         },
 
         /**
@@ -306,7 +307,8 @@ Place editable input.
         **/
         value2submit: function(values) {
             return {
-                position: this.marker.getLatLng().lat + ',' + this.marker.getLatLng().lng,
+                position: this.marker.getLatLng().lat +
+                    ',' + this.marker.getLatLng().lng,
                 placeId: values.placeId,
                 placeName: values.placeName,
                 canonicalName: values.geoname,

--- a/media/js/xeditable/bootstrap-editable-place.js
+++ b/media/js/xeditable/bootstrap-editable-place.js
@@ -75,12 +75,10 @@ Place editable input.
                 this.mapInstance.removeLayer(this.marker);
             }
 
-            // Add new marker
             this.marker = L.marker(latlng, {
                 title: value.text
             }).addTo(this.mapInstance);
 
-            // Fit map bounds
             const bounds = L.latLngBounds(latlng, latlng);
             this.mapInstance.fitBounds(bounds);
             this.mapInstance.setZoom(10);
@@ -102,7 +100,6 @@ Place editable input.
 
             this.mapInstance = L.map(this.mapContainer, this.mapOptions);
 
-            // Stadia tiles
             L.tileLayer(Footprints.tileServer.url, {
                 maxZoom: 20,
                 attribution: Footprints.tileServer.attribution

--- a/media/js/xeditable/bootstrap-editable-place.js
+++ b/media/js/xeditable/bootstrap-editable-place.js
@@ -18,22 +18,12 @@ Place editable input.
         this.placeUrl = Footprints.baseUrl + 'api/altname';
 
         // Europe, @todo - allow this to be configurable
-        this.defaultLatLng = new google.maps.LatLng(
-            48.6908333333, 9.14055555556);
+        this.defaultLatLng = [48.6908333333, 9.14055555556];
 
         this.mapOptions = {
-            zoom: 3,
             center: this.defaultLatLng,
-            mapTypeId: google.maps.MapTypeId.ROADMAP,
-            zoomControl: true,
-            zoomControlOptions: {
-                style: google.maps.ZoomControlStyle.SMALL,
-                position: google.maps.ControlPosition.RIGHT_BOTTOM
-            },
-            mapTypeControl: false,
-            streetViewControl: false,
-            fullscreenControl: false,
-            controlSize: 28
+            zoom: 3,
+            zoomControl: true
         };
     };
 
@@ -72,27 +62,26 @@ Place editable input.
         onPlaceClear: function() {
             this.$altname.val(null).trigger('change');
             if (this.marker) {
-                this.marker.setMap(null);
+                this.mapInstance.removeLayer(this.marker);
+                this.marker = null;
             }
         },
         onPlaceChange: function() {
             const value = this.$geoname.select2('data')[0];
+            const latlng = [value.lat, value.lng];
 
-            let latlng = new google.maps.LatLng(value.lat, value.lng);
-
-            // Create a marker for the place.
+            // Remove previous marker
             if (this.marker) {
-                this.marker.setMap(null);
+                this.mapInstance.removeLayer(this.marker);
             }
-            this.marker = new google.maps.Marker({
-                map: this.mapInstance,
-                title: value.text,
-                position: latlng,
-                animation: google.maps.Animation.DROP
-            });
 
-            let bounds = new google.maps.LatLngBounds();
-            bounds.extend(latlng);
+            // Add new marker
+            this.marker = L.marker(latlng, {
+                title: value.text
+            }).addTo(this.mapInstance);
+
+            // Fit map bounds
+            const bounds = L.latLngBounds(latlng, latlng);
             this.mapInstance.fitBounds(bounds);
             this.mapInstance.setZoom(10);
 
@@ -111,9 +100,13 @@ Place editable input.
             this.mapContainer =
                 this.$tpl.find('.map-container')[0];
 
-            this.mapInstance = new google.maps.Map(
-                this.mapContainer,
-                this.mapOptions);
+            this.mapInstance = L.map(this.mapContainer, this.mapOptions);
+
+            // Stadia tiles
+            L.tileLayer(Footprints.tileServer.url, {
+                maxZoom: 20,
+                attribution: Footprints.tileServer.attribution
+            }).addTo(this.mapInstance);
 
             this.$geoname = this.$tpl.find('[name="geoname"]').first();
             this.$geoname.select2({
@@ -211,8 +204,8 @@ Place editable input.
             });
 
             setTimeout(() => {
-                google.maps.event.trigger(this.mapInstance, 'resize');
-                this.mapInstance.setCenter(this.defaultLatLng);
+                this.mapInstance.invalidateSize();
+                this.mapInstance.setView(this.defaultLatLng, this.mapOptions.zoom);
             }, 0);
         },
 
@@ -230,7 +223,7 @@ Place editable input.
 
            @method html2value(html)
         **/
-        html2value: function(html) {
+        html2value: function(html) { 
             return null;
         },
 
@@ -240,7 +233,7 @@ Place editable input.
 
            @method value2str(value)
         **/
-        value2str: function(value) {
+       value2str: function(value) {
             var str = '';
             if (value) {
                 var keys = Object.keys(value);
@@ -263,7 +256,7 @@ Place editable input.
               attribute. If you will always set value by javascript,
               no need to overwrite it
             */
-            return str;
+           return str;
         },
 
         /**
@@ -292,8 +285,9 @@ Place editable input.
             values.error = this.validate();
 
             if (this.marker !== undefined) {
-                values.latitude = this.marker.getPosition().lat();
-                values.longitude = this.marker.getPosition().lng();
+                const latlng = this.marker.getLatLng();
+                values.latitude = latlng.lat;
+                values.longitude = latlng.lng;
                 values.geoname = this.$geoname.select2('data')[0].text;
                 values.geonameId = this.$geoname.select2('data')[0].id;
 
@@ -315,7 +309,7 @@ Place editable input.
         **/
         value2submit: function(values) {
             return {
-                position: this.marker.getPosition().toUrlValue(),
+                position: this.marker.getLatLng().lat + ',' + this.marker.getLatLng().lng,
                 placeId: values.placeId,
                 placeName: values.placeName,
                 canonicalName: values.geoname,


### PR DESCRIPTION
This PR migrates the Footprint detail and Written Work detail pages from Google Maps to a Leaflet/OpenStreetMaps/Stadia Tile Server stack. Some notes:

- Leaflet spiders map markers as part of its core functionality. You'll see a fair amount of code was removed that relied on the Spiderfier add-on.
- I've left the Google Maps script includes in place and will clean that up after the migration is complete.
- We'll be on Stadia's free tier until we put a credit card in place. (I want to make sure this is all working as expected before completing that transaction.)
- Stadia does domain verification rather than using an API key for web apps, so no additional secret configuration should be needed.


### Test Cases

For all cases, keep the Inspect window open to look for unexpected Javascript errors.

* View
** Review an existing Footprints Detail page that has a Footprint place and Imprint place specified.
** Verify the page and the map render as expected.

* Edit
** Login to Footprint
** Create a Test or Sample Footprint.
** Verify the page renders as expected.
** Add a place to the Footprint.
** Add a place to the Imprint.
** Verify the Footprint and Imprint maps render as expected.

* Search & Written Work page
** Navigate to the Search page
** Click a Written Work link (5th column)
** Verify the Written Work detail page render as expected.
** Verify the map renders properly. Markers cluster and uncluster as the user zooms in & out.

* Pathmapper
** Navigate to Pathmapper.
** Functionality should still be broken here. Next PR will resolve.