### PR TITLE
:arrow_up: bootstrap 3.4.1

### DIFF
--- a/footprints/templates/base.html
+++ b/footprints/templates/base.html
@@ -15,7 +15,8 @@
         {% endblock %}
 
         <!-- Bootstrap CSS: -->
-        <link href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css" rel="stylesheet">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@3.4.1/dist/css/bootstrap.min.css" integrity="sha384-HSMxcRTRxnN+Bdg0JdbxYKrThecOKuH5zCYotlSAcp1+c8xmyTe9GYg1l9a69psu" crossorigin="anonymous">
+
             <!-- Application CSS: -->
             <link href="{{STATIC_URL}}css/main.css" rel="stylesheet">
             {% block css %}{% endblock %}
@@ -215,8 +216,7 @@
             crossorigin="anonymous"></script>
     <script src="{{STATIC_URL}}js/backbone-min.js"
             crossorigin="anonymous"></script>
-    <script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.6/js/bootstrap.min.js"
-            crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@3.4.1/dist/js/bootstrap.min.js" integrity="sha384-aJ21OjlMXNL5UyIl/XNwTMqvzeRMZH2w8c5cRVpzpU8Y5bApTppSuUkhZXN0VxHd" crossorigin="anonymous"></script>
 
     <script>
         const Footprints = {

--- a/footprints/templates/design/pathmapper.html
+++ b/footprints/templates/design/pathmapper.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <title>Footprints: PathMapper</title>
-    
+
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -10,15 +10,16 @@
     <meta name="author" content="CTL">
     <meta name="robots" content="noindex">
     <meta name="googlebot" content="noindex">
-  
+
     <!-- Bootstrap CSS: -->
-    <link href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@3.4.1/dist/css/bootstrap.min.css" integrity="sha384-HSMxcRTRxnN+Bdg0JdbxYKrThecOKuH5zCYotlSAcp1+c8xmyTe9GYg1l9a69psu" crossorigin="anonymous">
+
         <!-- Application CSS: -->
         <link href="{{STATIC_URL}}css/main.css" rel="stylesheet">
         <link href="{{STATIC_URL}}css/custom-responsive.css" rel="stylesheet">
         <link href="{{STATIC_URL}}css/print-pathmapper.css" rel="stylesheet" media="print">
-    <link rel="shortcut icon" href="{{STATIC_URL}}img/favicon.ico" type="image/x-icon" /> 
-  
+    <link rel="shortcut icon" href="{{STATIC_URL}}img/favicon.ico" type="image/x-icon" />
+
     <script src="{{STATIC_URL}}jquery/js/jquery-1.12.4.min.js"
             crossorigin="anonymous"></script>
     <link href="//fonts.googleapis.com/css?family=Asap:400,700,400italic" rel="stylesheet" type="text/css">
@@ -95,11 +96,11 @@
         {% endif %}
         <li class="fp_socialmedia"><a href="https://www.facebook.com/footprintsHeb/" target="_blank" title="Footprints on Facebook"><img src="{{STATIC_URL}}img/footer_fb_logo.png" target="_blank" alt="Footprints on Facebook"></a></li>
         <li class="fp_socialmedia"><a href="https://twitter.com/Footprints_Heb" target="_blank" title="Footprints on Twitter"><img src="{{STATIC_URL}}img/footer_twitter_logo.png" target="_blank" alt="Footprints on Twitter"></a></li>
-    </ul>                    
-    
+    </ul>
+
     <div class="footer-branding">
         <p class="description1">Footprints grew out of the Scholars Working Group on the Jewish Book at the Center for Jewish History and was developed as a collaboration of educators and researchers from the following institutions:</p>
-        
+
         <div class="institutions-research clearfix">
             <div class="footer-line1">
             <div class="logos-ir"><a href="http://www.jtsa.edu/" class="hidden-print" /><img src="{{STATIC_URL}}img/fp_jts_logo.png" target="_blank" alt="Jewish Theological Seminary" class="hidden-print" /></a>
@@ -118,7 +119,7 @@
             </div>
             </div>
         </div>
-        
+
         <p class="description2">This project was made possible by generous support from:</p>
 
         <ul class="footer-logos footer-line3">
@@ -135,6 +136,6 @@
 
 
 </div><!-- /#wrap -->
-<script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.6/js/bootstrap.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@3.4.1/dist/js/bootstrap.min.js" integrity="sha384-aJ21OjlMXNL5UyIl/XNwTMqvzeRMZH2w8c5cRVpzpU8Y5bApTppSuUkhZXN0VxHd" crossorigin="anonymous"></script>
 </body>
 </html>

--- a/footprints/templates/design/pathmappervision.html
+++ b/footprints/templates/design/pathmappervision.html
@@ -12,7 +12,7 @@
     <meta name="googlebot" content="noindex">
   
     <!-- Bootstrap CSS: -->
-    <link href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@3.4.1/dist/css/bootstrap.min.css" integrity="sha384-HSMxcRTRxnN+Bdg0JdbxYKrThecOKuH5zCYotlSAcp1+c8xmyTe9GYg1l9a69psu" crossorigin="anonymous">
         <!-- Application CSS: -->
         <link href="{{STATIC_URL}}css/main.css" rel="stylesheet">
         <link href="{{STATIC_URL}}css/custom-responsive.css" rel="stylesheet">
@@ -135,6 +135,6 @@
 
 
 </div><!-- /#wrap -->
-    <script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.6/js/bootstrap.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@3.4.1/dist/js/bootstrap.min.js" integrity="sha384-aJ21OjlMXNL5UyIl/XNwTMqvzeRMZH2w8c5cRVpzpU8Y5bApTppSuUkhZXN0VxHd" crossorigin="anonymous"></script>
 </body>
 </html>


### PR DESCRIPTION
It looks like I updated the bootstrap sources to 3.4.1 last summer, but not the bootstrap loaded via CDN here in the templates.