### PR TITLE
Update Cross-Origin Policy To Ensure Valid Referer

### DIFF
--- a/footprints/settings_shared.py
+++ b/footprints/settings_shared.py
@@ -193,4 +193,4 @@ ACCOUNT_ACTIVATION_DAYS = 7  # One-week activation window
 REGISTRATION_AUTO_LOGIN = False  # Do not automatically log the user in.
 
 SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
-SECURE_REFERRER_POLICY = "strict-origin-when-cross-origin"
+SECURE_REFERRER_POLICY = 'strict-origin-when-cross-origin'

--- a/footprints/settings_shared.py
+++ b/footprints/settings_shared.py
@@ -193,3 +193,4 @@ ACCOUNT_ACTIVATION_DAYS = 7  # One-week activation window
 REGISTRATION_AUTO_LOGIN = False  # Do not automatically log the user in.
 
 SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
+SECURE_REFERRER_POLICY = "strict-origin-when-cross-origin"


### PR DESCRIPTION
Per Stadia documentation, their "domain" verification works [via seeing the correct referer](https://docs.stadiamaps.com/authentication/). Our current settings send `same-origin` which effectively blocks the referer from passing through on a tile request. Updating to  the suggested `strict-origin-when-cross-origin` appears to resolve the issue.