### PR TITLE
Adjust search page styling

### DIFF
--- a/footprints/templates/main/pagination.html
+++ b/footprints/templates/main/pagination.html
@@ -17,7 +17,7 @@
         </a>
     </div>
     <div class="pull-right page-count">
-        Page <input data-base-url="{{base_url}}"
+        <span class="page-label">Page</span> <input data-base-url="{{base_url}}"
                 class="form-control page-number" type="text"
                 value="{{page_obj.number}}"> of <span class="max-page">{{paginator.num_pages}}</span>
         <p class="error-block small">
@@ -36,7 +36,7 @@
             {% else %}
                 href="#"
             {% endif %}>
-            <span class="glyphicon glyphicon-backward" aria-hidden="true"></span> Previous
+            <span class="glyphicon glyphicon-backward" aria-hidden="true"></span> Prev
         </a>
     </div>
 {% endif %}

--- a/footprints/templates/search/search.html
+++ b/footprints/templates/search/search.html
@@ -221,12 +221,6 @@
                 <button type="reset" class="btn btn-default" id="clear_primary_search">
                     <span class="glyphicon glyphicon-remove"></span> Clear
                 </button>
-                {% if form.is_bound and form.errors|length < 1 and search_criteria %}
-                <div class="filter-marker">
-                    Filters
-                </div>
-                {% endif %}
-
                 {% if form.q.errors %}
                 <br />
                 <div class="error-message">
@@ -236,6 +230,12 @@
             </div>
         </div>
     </div><!-- /.advanced-search-filter -->
+
+    {% if form.is_bound and form.errors|length < 1 and search_criteria %}
+    <div class="filter-marker">
+        Advanced Filters
+    </div>
+    {% endif %}
 
     {% if form.is_bound and form.errors|length < 1 and search_criteria %}
     <div class="advanced-search-filter" style="padding-top: 0;">
@@ -388,7 +388,7 @@
 
     <!-- Results navigation  -->
     <div class="row tools results-navigation">
-        <div class="col-xs-6">
+        <div class="col-xs-7">
             <div class="total-results-count">
                 {{paginator.count}} footprints
             </div>
@@ -421,7 +421,7 @@
             </div>
             {% endflag %}
         </div>
-        <div class="col-xs-6">
+        <div class="col-xs-5">
             {% include 'main/pagination.html' %}
         </div>
     </div>

--- a/media/css/main.css
+++ b/media/css/main.css
@@ -2387,15 +2387,13 @@ th.sortable.tablesorter-headerDesc,
 
 .advanced-search-filter {
     background: #f0f0f0 url("../img/fp_section_bg.png") repeat;
-    padding: 10px 15px;
-    margin: 0 -15px;
+    padding: 10px;
 }
 
 .advanced-search-filter .search-level,
-.advanced-search-filter .error-level
-{
+.advanced-search-filter .error-level {
     position: relative;
-    margin: 0;
+    padding: 10px 20px;
 }
 
 .advanced-search-filter .filter-level {
@@ -2405,35 +2403,12 @@ th.sortable.tablesorter-headerDesc,
 	position: relative;
 }
 
-.advanced-search-filter .filter-level:after, .advanced-search-filter .filter-level:before {
-	bottom: 100%;
-	right: 55px;
-	border: solid transparent;
-	content: " ";
-	height: 0;
-	width: 0;
-	position: absolute;
-	pointer-events: none;
-}
-
-.advanced-search-filter .filter-level:after {
-	border-color: rgba(240, 240, 240, 0);
-	border-bottom-color: #f0f0f0;
-	border-width: 10px;
-	margin-right: 1px;
-}
-.advanced-search-filter .filter-level:before {
-	border-color: rgba(153, 153, 153, 0);
-	border-bottom-color: #999;
-	border-width: 11px;
-	margin-left: -11px;
-}
-
 .advanced-search-filter .col-q-field,
 .advanced-search-filter .col-q-error,
 .advanced-search-filter .col-q {
     float: left;
-    width: 150px;
+    width: 200px;
+    margin-right: 15px;
 }
 
 .advanced-search-filter .col-fyear-field,
@@ -2442,7 +2417,23 @@ th.sortable.tablesorter-headerDesc,
 .advanced-search-filter .col-pub-year
 {
     float: left;
-    width: 200px;
+    width: 150px;
+    margin-right: 15px;
+    margin-bottom: 15px;
+}
+
+.advanced-search-filter .col-footprint-year input.start-year,
+.advanced-search-filter .col-footprint-year button.toggle-range,
+.advanced-search-filter .col-footprint-year input.end-year,
+.advanced-search-filter .col-pub-year input.start-year,
+.advanced-search-filter .col-pub-year button.toggle-range,
+.advanced-search-filter .col-pub-year input.end-year {
+    margin-bottom: 4px;
+}
+
+.advanced-search-filter .col-footprint-year .form-group,
+.advanced-search-filter .col-pub-year .form-group {
+    margin-bottom: 0px !important;
 }
 
 .advanced-search-filter .col-submit
@@ -2468,7 +2459,7 @@ th.sortable.tablesorter-headerDesc,
 }
 
 .advanced-search-filter .search-level button {
-    margin-top: 25px;
+
 }
 
 .advanced-search-filter .search-level button.btn-gray {
@@ -2480,12 +2471,6 @@ th.sortable.tablesorter-headerDesc,
 .advanced-search-filter .col-footprint-year .toggle-range {
     display: inline-block;
     vertical-align: middle;
-}
-
-.advanced-search-filter .search-level .toggle-range {
-    margin: 0 2px;
-    padding-top: 2px;
-    line-height: 32px;
 }
 
 .advanced-search-filter .toggle-range:before {
@@ -2500,14 +2485,36 @@ th.sortable.tablesorter-headerDesc,
     content: "\e083";
 }
 
-.advanced-search-filter .filter-marker {
-    margin-top: 30px;
-    float: right;
-    width: 130px;
-    vertical-align: bottom;
-    text-align: center;
+.filter-marker {
+    background: #f0f0f0 url("../img/fp_section_bg.png") repeat;
+    padding: 0 10px;
     font-size: 14px;
     font-weight: 700;
+    text-align: right;
+}
+
+.advanced-search-filter .filter-level:after, .advanced-search-filter .filter-level:before {
+	bottom: 100%;
+	right: 110px;
+	border: solid transparent;
+	content: " ";
+	height: 0;
+	width: 0;
+	position: absolute;
+	pointer-events: none;
+}
+
+.advanced-search-filter .filter-level:after {
+	border-color: rgba(240, 240, 240, 0);
+	border-bottom-color: #f0f0f0;
+	border-width: 10px;
+	margin-right: 1px;
+}
+.advanced-search-filter .filter-level:before {
+	border-color: rgba(153, 153, 153, 0);
+	border-bottom-color: #999;
+	border-width: 11px;
+	margin-left: -11px;
 }
 
 .advanced-search-filter .filter-level .start-year,
@@ -2551,6 +2558,19 @@ th.sortable.tablesorter-headerDesc,
 
 .results-navigation {
     margin-top: 10px;
+}
+
+.btn-paginate {
+    margin-top: 10px;
+    margin-bottom: 10px;
+}
+
+.results-navigation button.toggle-view {
+    margin-top: 10px;
+}
+
+.results-navigation span.page-label {
+    display: none;
 }
 
 .total-results-count {
@@ -3173,8 +3193,6 @@ p.decoy {
     .advanced-search-filter .col-q-field,
     .advanced-search-filter .col-q-error,
     .advanced-search-filter .col-q {
-        padding-left: 15px;
-        padding-right: 15px;
         width: 200px;
     }
     .advanced-search-filter .col-fyear-field,
@@ -3190,11 +3208,25 @@ p.decoy {
     .advanced-search-filter .col-submit {
         padding-left: 0px;
         padding-right: 15px;
-        width: 369px;
+        width: 265px;
+        margin-top: 24px;
     }
 
     .object-detail.writtenwork .imprint-list-container dl dd {
         padding-left: 120px;
+    }
+
+    .btn-paginate {
+        margin-top: 0px;
+        margin-bottom: 10px;
+    }
+
+    .results-navigation button.toggle-view {
+        margin-top: 0px;
+    }
+
+    .results-navigation span.page-label {
+        display: inline;
     }
 }
 
@@ -3202,8 +3234,6 @@ p.decoy {
     .advanced-search-filter .col-q-field,
     .advanced-search-filter .col-q-error,
     .advanced-search-filter .col-q {
-        padding-left: 15px;
-        padding-right: 15px;
         width: 300px;
     }
     .advanced-search-filter .col-fyear-field,
@@ -3219,7 +3249,12 @@ p.decoy {
     .advanced-search-filter .col-submit {
         padding-left: 0px;
         padding-right: 15px;
-        width: 469px;
+        width: 360px;
+        margin-top: 24px;
+    }
+    .btn-paginate {
+        margin-top: 0px;
+        margin-bottom: 0px;
     }
 }
 

--- a/media/css/main.css
+++ b/media/css/main.css
@@ -2403,6 +2403,30 @@ th.sortable.tablesorter-headerDesc,
 	position: relative;
 }
 
+.advanced-search-filter .filter-level:after, .advanced-search-filter .filter-level:before {
+	bottom: 100%;
+	right: 110px;
+	border: solid transparent;
+	content: " ";
+	height: 0;
+	width: 0;
+	position: absolute;
+	pointer-events: none;
+}
+
+.advanced-search-filter .filter-level:after {
+	border-color: rgba(240, 240, 240, 0);
+	border-bottom-color: #f0f0f0;
+	border-width: 10px;
+	margin-right: 1px;
+}
+.advanced-search-filter .filter-level:before {
+	border-color: rgba(153, 153, 153, 0);
+	border-bottom-color: #999;
+	border-width: 11px;
+	margin-left: -11px;
+}
+
 .advanced-search-filter .col-q-field,
 .advanced-search-filter .col-q-error,
 .advanced-search-filter .col-q {
@@ -2491,30 +2515,6 @@ th.sortable.tablesorter-headerDesc,
     font-size: 14px;
     font-weight: 700;
     text-align: right;
-}
-
-.advanced-search-filter .filter-level:after, .advanced-search-filter .filter-level:before {
-	bottom: 100%;
-	right: 110px;
-	border: solid transparent;
-	content: " ";
-	height: 0;
-	width: 0;
-	position: absolute;
-	pointer-events: none;
-}
-
-.advanced-search-filter .filter-level:after {
-	border-color: rgba(240, 240, 240, 0);
-	border-bottom-color: #f0f0f0;
-	border-width: 10px;
-	margin-right: 1px;
-}
-.advanced-search-filter .filter-level:before {
-	border-color: rgba(153, 153, 153, 0);
-	border-bottom-color: #999;
-	border-width: 11px;
-	margin-left: -11px;
 }
 
 .advanced-search-filter .filter-level .start-year,


### PR DESCRIPTION
Small adjustments to the search controls, advanced filters and results rows. The Search/Clear buttons were incorrectly wrapping due to some page-level changes. Taking a minute to make the responsive views just a shade better. (This app predates much of the modern responsive and accessibility focus we now do automatically.)

1. Ensure the Search/Clear buttons layout on the same row as the Keyword, Footprint Year and Publication Year on larger screens.
2. When advanced filters are displayed, moved the "Filters" label directly to the horizontal separator.
3. Add vertical spacing throughout once the fields wrap to table or phone breakpoints.
