### PR TITLE
Revert "Bump sentry-sdk from 2.67.1 to 2.68.0"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -79,7 +79,7 @@ django-paging==0.2.5
 django-appconf==1.2.0
 django-statsd-mozilla==0.4.0
 raven==6.10.0
-sentry-sdk[django]==2.68.0
+sentry-sdk[django]==2.67.1
 django-bootstrap-form==3.4
 django-debug-toolbar==7.1.0
 django-waffle==5.0.0


### PR DESCRIPTION
Reverts ccnmtl/footprints#3644