### PR TITLE
Fix-ish for FOOTPRINTS-F2

### DIFF
--- a/footprints/templates/main/writtenwork_detail.html
+++ b/footprints/templates/main/writtenwork_detail.html
@@ -3,9 +3,12 @@
 {% block title %}Written Work {{object.title}}{% endblock %}
 
 {% block css %}
-    <link rel="stylesheet" href="https://unpkg.com/leaflet/dist/leaflet.css" />
-    <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster/dist/MarkerCluster.css" />
-    <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster/dist/MarkerCluster.Default.css" />
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
+        integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin="anonymous" />
+    <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.5.3/dist/MarkerCluster.css"
+        integrity="sha256-YU3qCpj/P06tdPBJGPax0bm6Q1wltfwjsho5TR4+TYc=" crossorigin="anonymous" />
+    <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.5.3/dist/MarkerCluster.Default.css"
+        integrity="sha256-YSWCMtmNZNwqex4CEw1nQhvFub2lmU7vcCKP+XVwwXA=" crossorigin="anonymous" />
 {% endblock %}
 
 {% block description %}
@@ -53,8 +56,10 @@
 {% endblock %}
 
 {% block js %}
-    <script src="https://unpkg.com/leaflet/dist/leaflet.js"></script>
-    <script src="https://unpkg.com/leaflet.markercluster/dist/leaflet.markercluster.js"></script>
+    <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
+        integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin="anonymous"></script>
+    <script src="https://unpkg.com/leaflet.markercluster@1.5.3/dist/leaflet.markercluster.js"
+        integrity="sha256-Hk4dIpcqOSb0hZjgyvFOP+cEmDXUKKNE/tT542ZbNQg=" crossorigin="anonymous"></script>
 
     <script src="{{STATIC_URL}}js/underscore-min.js"
             crossorigin="anonymous"></script>

--- a/footprints/templates/pathmapper/map.html
+++ b/footprints/templates/pathmapper/map.html
@@ -3,7 +3,8 @@
 {% block title %}Pathmapper{% endblock %}
 
 {% block css %}
-    <link rel="stylesheet" href="https://unpkg.com/leaflet/dist/leaflet.css" />
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
+        integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin="anonymous" />
     <link href="{{STATIC_URL}}css/pathmapper-tool.css" rel="stylesheet">
     <link href="{{STATIC_URL}}js/lib/select2-4.0.10/css/select2.min.css" rel="stylesheet">
     <link href="{{STATIC_URL}}css/select2-custom.css" rel="stylesheet">
@@ -95,7 +96,8 @@
         load.
     -->
     {{ layers|json_script:"layers" }}
-    <script src="https://unpkg.com/leaflet/dist/leaflet.js"></script>
+    <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
+        integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin="anonymous"></script>
 
     <script src="https://code.highcharts.com/8.2.0/highcharts.js"></script>
     <script src="https://code.highcharts.com/8.2.0/modules/heatmap.js"></script>

--- a/media/js/app/imprint-detail.js
+++ b/media/js/app/imprint-detail.js
@@ -16,9 +16,6 @@
 
             this.urlBase = options.urlBase;
 
-            this.footprintIcon = this.iconWithColor('#ffa881');
-            this.imprintIcon = this.iconWithColor('#5e98b7');
-
             this.shareTemplate =
                 _.template(jQuery(options.shareTemplate).html());
 
@@ -64,7 +61,7 @@
             return dataId.indexOf('footprint') > -1 ?
                 this.footprintIcon : this.imprintIcon;
         },
-        iconWithColor: function(color, multiple) {
+        iconWithColor: function(color) {
             return L.divIcon({
                 className: 'custom-marker',
                 html: `
@@ -85,6 +82,14 @@
             var self = this;
             var markers = jQuery(this.el).find('.map-marker');
             if (markers.length > 0) {
+                if (typeof L === 'undefined') {
+                    console.error(
+                        'Leaflet is unavailable. Skipping the imprint map.');
+                    return;
+                }
+
+                this.footprintIcon = this.iconWithColor('#ffa881');
+                this.imprintIcon = this.iconWithColor('#5e98b7');
 
                 this.resize();
 
@@ -219,6 +224,10 @@
             return $parent;
         },
         syncMap: function($parent, activeId) {
+            if (!this.map) {
+                return;
+            }
+
             var subset = [];
             var highlight;
 


### PR DESCRIPTION
Icons are built inside initializeMap, behind an explicit typeof L === 'undefined' check that logs to the console and skips only the map. The rest of the view survives a CDN failure.

Made 1.9.4 explicit (if and when 2.0 comes out it will be dropping the global L so we can tackle that later).
Dropped the unused multiple arg on iconWithColor, left over from the Google Maps version.